### PR TITLE
Run rack with host and port specificed in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ WEB_SERVER_PORT="7000"
 ASSET_SERVER_PORT="7001"
 
 # rack
-PORT="7000"
 MODE="dev"
 
 # keys

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: RACK_ENV=production VERSION=$VERSION MODE=prod bundle exec thin start -p $PORT
+web: RACK_ENV=production VERSION=$VERSION MODE=prod bundle exec thin start -p $WEB_SERVER_PORT

--- a/Procfile.cold
+++ b/Procfile.cold
@@ -1,1 +1,1 @@
-web: RACK_ENV=dev MODE=prod rackup -p $PORT
+web: RACK_ENV=dev MODE=prod rackup -o $WEB_SERVER_HOST -p $WEB_SERVER_PORT

--- a/Procfile.hot
+++ b/Procfile.hot
@@ -1,2 +1,2 @@
-web: rackup -p $PORT
+web: rackup -o $WEB_SERVER_HOST -p $WEB_SERVER_PORT
 assets: npm run dev

--- a/assets/dev-server.js
+++ b/assets/dev-server.js
@@ -18,7 +18,10 @@ var devServer = new WebpackDevServer(webpack(config), {
   hot: true,
   historyApiFallback: true,
   proxy: {
-    '*': 'http://' + WEB_SERVER_HOST + ':' + WEB_SERVER_PORT
+    '**': {
+      target: 'http://' + WEB_SERVER_HOST + ':' + WEB_SERVER_PORT,
+      secure: false
+    }
   },
   stats: {
     colors: true,


### PR DESCRIPTION
Rack was listening on `localhost` and `PORT` instead of `WEB_SERVER_HOST`  and `WEB_SERVER_PORT`, which means the new proxy set-up wasn't working with the Windows VMs.