### PR TITLE
Deprecate tabbed-course

### DIFF
--- a/assets/targets/components/_print.scss
+++ b/assets/targets/components/_print.scss
@@ -98,8 +98,7 @@ $white: #ffffff;
     }
 
     [role="main"] {
-      .tabbed-nav,
-      .tabbed-course {
+      .tabbed-nav {
         .desktop-nav,
         .mobile-nav {
           display: none;
@@ -240,7 +239,6 @@ $white: #ffffff;
 
       .alt,
       .layout-sidebar__side,
-      .tabbed-course .half,
       .contact-box {
         background: $white;
       }
@@ -278,10 +276,6 @@ $white: #ffffff;
         p {
           text-align: left;
         }
-      }
-
-      .tabbed-course > .full-width {
-        border: 0 none;
       }
 
       header .bottom-align-flat {

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -98,7 +98,7 @@ window.UOMloadComponents = function() {
     SidebarTabs = require("./tabs/sidebar-tabs");
     for (i=recs.length - 1; i >= 0; i--) {
       new SidebarTabs(recs[i], {
-        scrollTarget: document.querySelector('.tabbed-nav[data-tabbed], .tabbed-course[data-tabbed]')
+        scrollTarget: document.querySelector('.tabbed-nav[data-tabbed]')
       });
     }
   }

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -1,248 +1,6 @@
-@mixin tabbed-nav {
-  & > .full-width {
-    @include rem(height, $tabs-height);
-    background-color: $darkblue;
-    border-bottom: 1px solid transparent;
-    position: relative;
-    text-align: center;
-  }
-
-  & > figure.full-width {
-    background-color: transparent;
-  }
-
-  .mobile-nav {
-    display: none;
-  }
-
-  nav {
-    @include rem(padding, 0 40px);
-    display: inline-block;
-    white-space: nowrap;
-
-    a {
-      @include adjust-font-size-to(15px);
-      @include rem(line-height, $tabs-height);
-      @include rem(padding, 0 20px);
-      color: rgba($white, .7);
-      display: inline-block;
-      letter-spacing: .5px;
-      outline-offset: -1px;
-      text-decoration: none;
-      text-transform: uppercase;
-
-      &:hover {
-        text-decoration: underline;
-      }
-
-      &:hover,
-      &:focus {
-        color: $white;
-      }
-
-      &[data-current] {
-        color: $white;
-        font-weight: $regular;
-        position: relative;
-      }
-
-      &[data-current]::after {
-        border: solid transparent;
-        border-top-color: $darkblue;
-        border-width: 10px 10px 0;
-        content: ' ';
-        height: 0;
-        left: 50%;
-        margin-bottom: -10px;
-        margin-left: -10px;
-        pointer-events: none;
-        position: absolute;
-        top: 100%;
-        width: 0;
-        z-index: 10;
-      }
-
-      @include breakpoint(desktop) {
-        @include rem(padding, 0 30px);
-      }
-    }
-
-    [data-icon] {
-      // Fix outline bug in Chrome
-      overflow: hidden;
-      position: relative;
-
-      & > .icon-label {
-        @include screenreaders-only;
-      }
-    }
-  }
-
-  // wrapper added dynamically around nav element when tabs overflow
-  .tabbed-nav__inner {
-    @include rem(padding-bottom, 15px);
-    position: relative;
-    z-index: 1;
-  }
-
-  .ps-scrollbar-x-rail {
-    z-index: 5;
-  }
-
-  // show scrollbar when focused
-  .ps-focus .ps-scrollbar-x-rail {
-    opacity: 1;
-  }
-
-  // left/right arrows when screen size is too small to fit all the tabs
-  .tab-arrow {
-    @include rem(font-size, 30px);
-    @include rem(padding, 0 20px 5px); // bottom padding aligns arrows with tab labels
-    background: $darkblue;
-    color: $white;
-    cursor: pointer;
-    display: none;
-    font-weight: $bold;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    z-index: 2;
-
-    &[disabled] {
-      cursor: default;
-      opacity: .5;
-    }
-
-    &:focus {
-      outline: 1px dotted $white;
-    }
-  }
-
-  .tab-arrow--left {
-    @include rem(padding-right, 10px);
-    background: linear-gradient(to left, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
-    left: 0;
-  }
-
-  .tab-arrow--right {
-    @include rem(padding-left, 10px);
-    background: linear-gradient(to right, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
-    right: 0;
-  }
-
-  // show the arrows when the tabs overflow
-  .overflow .tab-arrow {
-    display: inline-block;
-  }
-
-  & > [role="tabpanel"] {
-    @include clearfix;
-    @include rem(margin-top, -70px);
-    @include rem(padding-top, 70px);
-    margin-left: auto;
-    max-width: 100%;
-    padding-bottom: 0;
-    padding-left: 0;
-    padding-right: 0;
-
-    section.lead {
-      background: transparent;
-      color: $black;
-      filter: none;
-      font-weight: $light;
-      margin: 0 auto;
-      max-width: $w-mid;
-      position: static;
-
-      p {
-        color: $black;
-      }
-    }
-  }
-
-  &.black {
-    .full-width {
-      background-color: $black;
-    }
-
-    figure.full-width {
-      background-color: transparent;
-    }
-
-    & > [role="tabpanel"] {
-      @include rem(margin-top, -76px);
-      @include rem(padding-top, 76px);
-    }
-
-    nav a {
-      color: $white;
-
-      &[data-current] {
-        color: $white;
-        font-weight: $regular;
-
-        &:after {
-          border-top-color: $black;
-        }
-      }
-    }
-
-    .mobile-nav,
-    .mobile-nav select {
-      background-color: $black;
-      border: 1px solid $black;
-    }
-  }
-
-  &.navy {
-    .full-width {
-      background-color: $darkblue;
-    }
-
-    figure.full-width {
-      background-color: transparent;
-    }
-
-    & > [role="tabpanel"] {
-      @include rem(margin-top, -76px);
-      @include rem(padding-top, 76px);
-    }
-
-    nav a {
-      color: $gray;
-
-      &[data-current] {
-        color: $white;
-        font-weight: $regular;
-
-        &:after {
-          border-top-color: $darkblue;
-        }
-      }
-    }
-  }
-
-  &.thin {
-    nav a {
-      @include adjust-font-size-to(13px);
-      @include rem(line-height, $tabs-height - 2px); // leave 1px above and below for outline
-      @include rem(margin-top, 1px); // outline cont.
-      @include rem(padding, 0 15px);
-    }
-
-    & > [role="tabpanel"] {
-      @include rem(margin-top, -55px);
-      @include rem(padding-top, 55px);
-      background-color: transparent;
-
-      @include breakpoint(desktop) {
-        @include rem(margin-top, -95px);
-        @include rem(padding-top, 95px);
-      }
-    }
-  }
-}
-
+/**
+ * In-page tabs
+ */
 [data-tabbed].tabbed {
   @include clearfix;
   @include trailer(2);
@@ -298,6 +56,7 @@
 }
 
 .uomcontent {
+  /* styles shared between full-width and in-page tabs */
   [data-tabbed] {
     nav {
       a {
@@ -334,21 +93,251 @@
     cursor: pointer;
   }
 
+  /**
+   * Full-width tabs
+   */
   .tabbed-nav {
-    @include tabbed-nav;
-  }
-}
-
-.uomcontent [role="main"] {
-  .tabbed-course {
-    @include tabbed-nav;
-
-    .aside h2.subtitle {
-      @include rem(padding-bottom, 5px);
+    & > .full-width {
+      @include rem(height, $tabs-height);
+      background-color: $darkblue;
+      border-bottom: 1px solid transparent;
+      position: relative;
+      text-align: center;
     }
 
-    .mobile-wrap {
-      overflow: visible;
+    & > figure.full-width {
+      background-color: transparent;
+    }
+
+    .mobile-nav {
+      display: none;
+    }
+
+    nav {
+      @include rem(padding, 0 40px);
+      display: inline-block;
+      white-space: nowrap;
+
+      a {
+        @include adjust-font-size-to(15px);
+        @include rem(line-height, $tabs-height);
+        @include rem(padding, 0 20px);
+        color: rgba($white, .7);
+        display: inline-block;
+        letter-spacing: .5px;
+        outline-offset: -1px;
+        text-decoration: none;
+        text-transform: uppercase;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        &:hover,
+        &:focus {
+          color: $white;
+        }
+
+        &[data-current] {
+          color: $white;
+          font-weight: $regular;
+          position: relative;
+        }
+
+        &[data-current]::after {
+          border: solid transparent;
+          border-top-color: $darkblue;
+          border-width: 10px 10px 0;
+          content: ' ';
+          height: 0;
+          left: 50%;
+          margin-bottom: -10px;
+          margin-left: -10px;
+          pointer-events: none;
+          position: absolute;
+          top: 100%;
+          width: 0;
+          z-index: 10;
+        }
+
+        @include breakpoint(desktop) {
+          @include rem(padding, 0 30px);
+        }
+      }
+
+      [data-icon] {
+        // Fix outline bug in Chrome
+        overflow: hidden;
+        position: relative;
+
+        & > .icon-label {
+          @include screenreaders-only;
+        }
+      }
+    }
+
+    // wrapper added dynamically around nav element when tabs overflow
+    .tabbed-nav__inner {
+      @include rem(padding-bottom, 15px);
+      position: relative;
+      z-index: 1;
+    }
+
+    .ps-scrollbar-x-rail {
+      z-index: 5;
+    }
+
+    // show scrollbar when focused
+    .ps-focus .ps-scrollbar-x-rail {
+      opacity: 1;
+    }
+
+    // left/right arrows when screen size is too small to fit all the tabs
+    .tab-arrow {
+      @include rem(font-size, 30px);
+      @include rem(padding, 0 20px 5px); // bottom padding aligns arrows with tab labels
+      background: $darkblue;
+      color: $white;
+      cursor: pointer;
+      display: none;
+      font-weight: $bold;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      z-index: 2;
+
+      &[disabled] {
+        cursor: default;
+        opacity: .5;
+      }
+
+      &:focus {
+        outline: 1px dotted $white;
+      }
+    }
+
+    .tab-arrow--left {
+      @include rem(padding-right, 10px);
+      background: linear-gradient(to left, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
+      left: 0;
+    }
+
+    .tab-arrow--right {
+      @include rem(padding-left, 10px);
+      background: linear-gradient(to right, rgba($darkblue, 0), rgba($darkblue, .9) 10%);
+      right: 0;
+    }
+
+    // show the arrows when the tabs overflow
+    .overflow .tab-arrow {
+      display: inline-block;
+    }
+
+    & > [role="tabpanel"] {
+      @include clearfix;
+      @include rem(margin-top, -70px);
+      @include rem(padding-top, 70px);
+      margin-left: auto;
+      max-width: 100%;
+      padding-bottom: 0;
+      padding-left: 0;
+      padding-right: 0;
+
+      section.lead {
+        background: transparent;
+        color: $black;
+        filter: none;
+        font-weight: $light;
+        margin: 0 auto;
+        max-width: $w-mid;
+        position: static;
+
+        p {
+          color: $black;
+        }
+      }
+    }
+
+    &.black {
+      .full-width {
+        background-color: $black;
+      }
+
+      figure.full-width {
+        background-color: transparent;
+      }
+
+      & > [role="tabpanel"] {
+        @include rem(margin-top, -76px);
+        @include rem(padding-top, 76px);
+      }
+
+      nav a {
+        color: $white;
+
+        &[data-current] {
+          color: $white;
+          font-weight: $regular;
+
+          &:after {
+            border-top-color: $black;
+          }
+        }
+      }
+
+      .mobile-nav,
+      .mobile-nav select {
+        background-color: $black;
+        border: 1px solid $black;
+      }
+    }
+
+    &.navy {
+      .full-width {
+        background-color: $darkblue;
+      }
+
+      figure.full-width {
+        background-color: transparent;
+      }
+
+      & > [role="tabpanel"] {
+        @include rem(margin-top, -76px);
+        @include rem(padding-top, 76px);
+      }
+
+      nav a {
+        color: $gray;
+
+        &[data-current] {
+          color: $white;
+          font-weight: $regular;
+
+          &:after {
+            border-top-color: $darkblue;
+          }
+        }
+      }
+    }
+
+    &.thin {
+      nav a {
+        @include adjust-font-size-to(13px);
+        @include rem(line-height, $tabs-height - 2px); // leave 1px above and below for outline
+        @include rem(margin-top, 1px); // outline cont.
+        @include rem(padding, 0 15px);
+      }
+
+      & > [role="tabpanel"] {
+        @include rem(margin-top, -55px);
+        @include rem(padding-top, 55px);
+        background-color: transparent;
+
+        @include breakpoint(desktop) {
+          @include rem(margin-top, -95px);
+          @include rem(padding-top, 95px);
+        }
+      }
     }
   }
 }

--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -23,7 +23,7 @@ function Tabs(el, props) {
   this.props.isOverflowing = false;
   this.props.isOverflowSetup = false;
   this.props.isLoadingPs = false;
-  this.props.isNav = this.el.classList.contains('tabbed-nav') || this.el.classList.contains('tabbed-course');
+  this.props.isNav = this.el.classList.contains('tabbed-nav');
   this.props.matchFoundForHash = false;
 
   // Event bindings

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -63,7 +63,7 @@ window.DSComponentsLoad = function() {
     SidebarTabs = require("../components/tabs/sidebar-tabs");
     for (i=recs.length - 1; i >= 0; i--) {
       new SidebarTabs(recs[i], {
-        scrollTarget: document.querySelector('.tabbed-nav[data-tabbed], .tabbed-course[data-tabbed]')
+        scrollTarget: document.querySelector('.tabbed-nav[data-tabbed]')
       });
     }
   }

--- a/views/templates/course.slim
+++ b/views/templates/course.slim
@@ -14,7 +14,7 @@ div role="main"
               option value="domestic" a domestic student
               option selected="selected" value="international" an international student
 
-  #nav.tabbed-course data-tabbed=""
+  #nav.tabbed-nav data-tabbed=""
     .full-width
       nav role="tablist"
         a role="tab" href="#overview" Overview

--- a/views/templates/fake-tab.slim
+++ b/views/templates/fake-tab.slim
@@ -14,7 +14,7 @@ div role="main"
               option value="domestic" a domestic student
               option selected="selected" value="international" an international student
 
-  #nav.tabbed-course data-tabbed=""
+  #nav.tabbed-nav data-tabbed=""
     .full-width
       nav role="tablist"
         ul


### PR DESCRIPTION
Fix #717 

### Breaking change!

This deprecates the `tabbed-course` class, which was just an alias for `tabbed-nav`. If your site uses the `tabbed-course` class to implement full-width tabs, simply replace it with `tabbed-nav`.