### PR TITLE
Remove icon-over hack

### DIFF
--- a/assets/targets/components/base/_layout.scss
+++ b/assets/targets/components/base/_layout.scss
@@ -180,13 +180,6 @@ body {
         @include rem(width, 24px);
       }
 
-      .icon-over {
-        @include rem(height, 24px);
-        @include rem(margin-left, -24px);
-        @include rem(margin-top, -24px);
-        @include rem(width, 24px);
-      }
-
       &:hover {
         background-color: $highlight;
         transition: all 0.2s linear;

--- a/assets/targets/components/buttons/_buttons.scss
+++ b/assets/targets/components/buttons/_buttons.scss
@@ -71,13 +71,6 @@
     &.small {
       @include rem(height, 20px);
       @include rem(width, 20px);
-
-      .icon-over {
-        @include rem(height, 20px);
-        @include rem(margin-left, -20px);
-        @include rem(margin-top, -20px);
-        @include rem(width, 20px);
-      }
     }
   }
 

--- a/assets/targets/components/events/_events-detail.scss
+++ b/assets/targets/components/events/_events-detail.scss
@@ -226,13 +226,6 @@
 
     .aside {
       padding-top: 0;
-
-      [data-icon] .icon-over {
-        @include rem(height, 20px);
-        @include rem(margin-left, -20px);
-        @include rem(margin-top, -20px);
-        @include rem(width, 20px);
-      }
     }
 
     .aside p {

--- a/assets/targets/components/events/_events.scss
+++ b/assets/targets/components/events/_events.scss
@@ -248,12 +248,6 @@
       .icon-label {
         display: inline;
       }
-
-      .icon-over {
-        @include rem(height, 13px);
-        @include rem(margin-left, -13px);
-        @include rem(width, 13px);
-      }
     }
 
     svg {

--- a/assets/targets/components/forms/_forms-select.scss
+++ b/assets/targets/components/forms/_forms-select.scss
@@ -114,17 +114,6 @@
     position: absolute;
   }
 
-  .icon-over {
-    @include rem(height, 30px);
-    @include rem(top, 5px);
-    @include rem(right, 7px);
-    @include rem(width, 30px);
-    cursor: pointer;
-    display: block;
-    position: absolute;
-    z-index: 1;
-  }
-
   &:hover select {
     background-color: $brand;
     border-color: $brand;

--- a/assets/targets/components/people/_profile-header.scss
+++ b/assets/targets/components/people/_profile-header.scss
@@ -81,8 +81,7 @@
     &__contact {
       @include rem(margin-bottom, 24px);
 
-      [data-icon],
-      [data-icon] > .icon-over {
+      [data-icon] {
         @include rem(height, 20px);
         @include rem(margin-top, 4px);
         @include rem(width, 20px);

--- a/assets/targets/components/search/_search-results.scss
+++ b/assets/targets/components/search/_search-results.scss
@@ -159,10 +159,6 @@
       & > [data-icon="lock"] {
         @include rem(width, 20px);
         @include rem(height, 20px);
-
-        & > .icon-over {
-          display: block;
-        }
       }
     }
   }

--- a/assets/targets/injection/header/index.scss
+++ b/assets/targets/injection/header/index.scss
@@ -150,13 +150,6 @@
           display: inline-block;
           line-height: 1;
           padding: 0;
-
-          span.icon-over {
-            @include rem(height, 20px);
-            @include rem(margin-left, -20px);
-            @include rem(width, 20px);
-            vertical-align: top;
-          }
         }
       }
 
@@ -406,13 +399,6 @@
     display: inline-block;
     line-height: 1;
     padding: 0;
-
-    span.icon-over {
-      @include rem(height, 20px);
-      @include rem(margin-left, -20px);
-      @include rem(width, 20px);
-      vertical-align: top;
-    }
   }
 
   @include breakpoint(desktop) {

--- a/assets/targets/injection/icons/_svg.scss
+++ b/assets/targets/injection/icons/_svg.scss
@@ -19,23 +19,11 @@
     &.small {
       @include rem(height, 24px);
       @include rem(width, 24px);
-
-      .icon-over {
-        @include rem(height, 24px);
-        @include rem(margin-left, -24px);
-        @include rem(width, 24px);
-      }
     }
 
     &.large {
       @include rem(height, 100px);
       @include rem(width, 100px);
-
-      .icon-over {
-        @include rem(height, 100px);
-        @include rem(margin-left, -100px);
-        @include rem(width, 100px);
-      }
     }
 
     &.fill {
@@ -63,15 +51,6 @@
       margin: 0;
       text-align: center;
       white-space: nowrap;
-    }
-
-    .icon-over {
-      @include rem(height, 60px);
-      @include rem(margin-left, -60px);
-      @include rem(width, 60px);
-      display: inline-block;
-      position: relative;
-      z-index: 1;
     }
   }
 

--- a/assets/targets/injection/icons/iconhelper.js
+++ b/assets/targets/injection/icons/iconhelper.js
@@ -19,7 +19,7 @@ function IconHelper(el, props) {
 
   // Inject the icon's SVG markup (without losing the label and any other pre-existing children)
   this.saveChildren();
-  this.el.innerHTML = '<svg class="icon" role="img"><use xlink:href="' + this.props.ref + '"></use></svg>';
+  this.el.innerHTML = '<svg class="icon" role="img" focusable="false"><use xlink:href="' + this.props.ref + '"></use></svg>';
   this.restoreChildren();
 }
 

--- a/assets/targets/injection/icons/iconhelper.js
+++ b/assets/targets/injection/icons/iconhelper.js
@@ -1,6 +1,5 @@
 /**
- * IconHelper
- *
+ * Icon helper
  * @param  {Element} el
  * @param  {Object} props
  */
@@ -8,44 +7,40 @@ function IconHelper(el, props) {
   this.el = el;
   this.props = props;
 
-  if (this.el.hasAttribute('data-bound')) {
-    return;
-  }
+  // Don't initialise the same icon twice
+  if (this.el.hasAttribute('data-bound')) return;
+  this.el.setAttribute('data-bound', true);
 
+  // Allow providing icon target with or without the `#icon-` prefix
   this.props.ref = this.el.getAttribute('data-icon');
-  if (this.props.ref.substr(0,5) != '#icon-') {
+  if (!/^#icon-/.test(this.props.ref)) {
     this.props.ref = '#icon-' + this.props.ref;
   }
 
+  // Inject the icon's SVG markup (without losing the label and any other pre-existing children)
   this.saveChildren();
-  this.el.innerHTML = '<svg class="icon" role="img"><use xlink:href="' + this.props.ref + '"></use></svg><span class="icon-over"></span>';
-
-  if (this.props.inner.length > 0) {
-    this.restoreChildren();
-  }
-
-  this.el.querySelector('.icon-over').addEventListener('click', this.passClickThrough.bind(this));
-  this.el.setAttribute('data-bound', true);
+  this.el.innerHTML = '<svg class="icon" role="img"><use xlink:href="' + this.props.ref + '"></use></svg>';
+  this.restoreChildren();
 }
 
 IconHelper.prototype.saveChildren = function() {
-  this.props.inner = [];
-  for (var recs=this.el.childNodes, i=recs.length - 1; i >= 0; i--)
-    this.props.inner.push(this.el.removeChild(recs[i]));
+  this.props.children = [];
+  for (var recs = this.el.childNodes, i = recs.length - 1; i >= 0; i--)
+    this.props.children.push(this.el.removeChild(recs[i]));
 };
 
 IconHelper.prototype.restoreChildren = function() {
+  // Skip if icon has no label
+  if (this.props.children.length === 0) return;
+
+  // Create label wrapper and move all pre-existing children into it
   var label = document.createElement('div');
   label.className = 'icon-label';
-  for (var recs=this.props.inner, i=recs.length - 1; i >= 0; i--)
+  for (var recs = this.props.children, i = recs.length - 1; i >= 0; i--)
     label.appendChild(recs[i]);
 
+  // Append the label to the DOM (after the SVG element)
   this.el.appendChild(label);
-};
-
-IconHelper.prototype.passClickThrough = function(e) {
-  e.preventDefault();
-  this.el.parentNode.click();
 };
 
 module.exports = IconHelper;


### PR DESCRIPTION
Don't inject `.icon-over` when binding icons, and prevent icons from beeing focusable in IE with `focusable="false"` (fix #669).

This shouldn't break anything. Any overrides targetting `icon-over` can safely be removed.