### PR TITLE
Force elements with `hidden` class or attribute to be hidden

### DIFF
--- a/assets/shared/_normalize.scss
+++ b/assets/shared/_normalize.scss
@@ -46,8 +46,9 @@ iframe[src^='//player.vimeo.com'] {
 }
 
 // Hide elements (prefer `hidden` attribute)
-.hidden {
-  display: none;
+.hidden,
+[hidden] {
+  display: none !important; /* force */
 }
 
 /* Hide outline on elements focused programmatically */


### PR DESCRIPTION
This ensures that elements are hidden even if they have a custom `display` property. Note that normalize.css doesn't set `!important` for `[hidden]`, which is why it's back in our own normalisation partial.

This should not break anything, but may uncover bugs where the `hidden` class or attribute was being set by mistake. Any overrides meant to work around this issue can now be removed, for instance:

```
/* REMOVE */
.element.hidden { display: none !important; }

/* REPLACE */
.element:not(hidden) { display: block; } /* BEFORE */
.element { display: block; } /* AFTER */