### PR TITLE
Distinguish degree structure headings and improve accordion accessibility

### DIFF
--- a/assets/targets/components/accordion/_accordion.scss
+++ b/assets/targets/components/accordion/_accordion.scss
@@ -113,7 +113,6 @@
 
         &:focus {
           color: $cyan;
-          outline: 0;
         }
 
         &:before {

--- a/assets/targets/components/accordion/index.js
+++ b/assets/targets/components/accordion/index.js
@@ -13,6 +13,7 @@ function Accordion(el, props) {
 
   this.setupCloseButton();
   this.el.setAttribute('tabindex', '0');
+  this.props.hidden.setAttribute('tabindex', '-1'); // make panel focusable
 
   // Event bindings
   if (!this.el.hasAttribute('data-bound')) {
@@ -46,6 +47,15 @@ Accordion.prototype.handleClick = function(e) {
   }
 
   this.props.container.classList.toggle('accordion__visible');
+
+  // Manage focus smartly to avoid having to remove the outline with CSS
+  if (this.props.container.classList.contains('accordion__visible')) {
+    // Focus panel on open
+    this.props.hidden.focus();
+  } else {
+    // Blur target on close
+    this.el.blur();
+  }
 };
 
 Accordion.prototype.setupCloseButton = function() {

--- a/assets/targets/components/base/_courses.scss
+++ b/assets/targets/components/base/_courses.scss
@@ -50,11 +50,6 @@
     &:hover {
       text-decoration: underline;
     }
-
-    &:hover,
-    &:focus {
-      color: darken($cyan, 15%);
-    }
   }
 
   .accordion__close {

--- a/assets/targets/components/base/_courses.scss
+++ b/assets/targets/components/base/_courses.scss
@@ -7,8 +7,6 @@
   width: 100%;
 
   th {
-    @include subtitle;
-    @include rem(font-size, 14px);
     @include rem(padding, 30px 0 10px);
     border-bottom: 1px solid $lightergray;
     border-left: 0 none;
@@ -16,13 +14,17 @@
     border-top: 0 none;
     padding-left: 0;
     padding-right: 3%;
-
     text-align: left;
 
     @include breakpoint(tablet) {
       padding-left: 0;
       padding-right: 0;
     }
+  }
+
+  thead th {
+    @include subtitle;
+    @include rem(font-size, 14px);
   }
 
   td {

--- a/assets/targets/components/base/_courses.scss
+++ b/assets/targets/components/base/_courses.scss
@@ -28,7 +28,6 @@
   }
 
   td {
-    @include rem(font-size, 14px);
     @include rem(padding-bottom, 10px);
     @include rem(padding-top, 10px);
     border-bottom: 1px solid $lightergray;
@@ -47,9 +46,13 @@
 
   .accordion__title {
     color: $cyan;
-    text-decoration: underline;
 
     &:hover {
+      text-decoration: underline;
+    }
+
+    &:hover,
+    &:focus {
       color: darken($cyan, 15%);
     }
   }
@@ -181,6 +184,10 @@
     h2 {
       margin: 0;
     }
+  }
+
+  tbody.accordion__visible tr.accordion__title {
+    font-weight: bold;
   }
 
   tbody.accordion__visible tr.accordion__hidden {


### PR DESCRIPTION
- Fix #486 - distinguish sub-headings in `course-progression` table
- Improve design of selectable rows in `course-progression` table: increase font size, remove default underline, show underline on hover, and bold when selected
- Get rid of the sticky focus outlines by managing focus of all accordions more smartly:
  - give focus to panel on open
  - blur trigger on close
  - => trigger no longer keeps focus after being clicked
  - => default focus outline can be restored to help keyboard users

<img width="807" alt="screen shot 2017-02-01 at 2 33 52 pm" src="https://cloud.githubusercontent.com/assets/2936402/22494502/1d1e6098-e88c-11e6-8dec-e94b905a074f.png">
