### PR TITLE
Fix max-width of Gmaps on small viewports

### DIFF
--- a/assets/targets/components/maps/_maps.scss
+++ b/assets/targets/components/maps/_maps.scss
@@ -1,7 +1,7 @@
 .uomcontent [role="main"] section {
   .map-canvas {
     height: 400px;
-    max-width: 600px;
+    max-width: 100%;
 
     img {
       max-width: none;


### PR DESCRIPTION
Fix #642

Gmaps always have a fixed width (400px by default), so the max-width can be 100% instead of 600px without compromising the design. This allows the maps do never overflow on mobile.