### PR TITLE
Gallery revamp

### DIFF
--- a/assets/targets/components/gallery/01-default-gallery.slim
+++ b/assets/targets/components/gallery/01-default-gallery.slim
@@ -8,7 +8,7 @@ ul.image-gallery
     a href="/assets/gallery/11.jpg" data-size="1000x1500"
       figure
         img src="/assets/gallery/thumbs/11.jpg" alt=""
-        figcaption Same caption in gallery as in viewer
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
   li.item
     a href="/assets/gallery/2.jpg" data-size="1500x1000"
       figure

--- a/assets/targets/components/gallery/01-default-gallery.slim
+++ b/assets/targets/components/gallery/01-default-gallery.slim
@@ -3,13 +3,12 @@ ul.image-gallery
     a href="/assets/gallery/1.jpg" data-size="1500x1000"
       figure
         img src="/assets/gallery/thumbs/1.jpg" alt=""
-        p.image-gallery__caption Image with short caption in gallery
         figcaption Lorem ipsum Duis exercitation dolore pariatur dolore.
   li.item
     a href="/assets/gallery/11.jpg" data-size="1000x1500"
       figure
         img src="/assets/gallery/thumbs/11.jpg" alt=""
-        figcaption.image-gallery__caption Same caption in gallery as in viewer
+        figcaption Same caption in gallery as in viewer
   li.item
     a href="/assets/gallery/2.jpg" data-size="1500x1000"
       figure
@@ -89,26 +88,4 @@ ul.image-gallery
     a href="/assets/gallery/18.jpg" data-size="1000x1500"
       figure
         img src="/assets/gallery/thumbs/18.jpg" alt=""
-        figcaption Lorem ipsum Proident do aute cupidatat enim.
-
-ul.image-gallery
-  li.item
-    a href="/assets/gallery/9.jpg" data-size="1500x1000"
-      figure
-        img src="/assets/gallery/thumbs/9.jpg" alt=""
-        figcaption Lorem ipsum Proident do aute cupidatat enim.
-  li.item
-    a href="/assets/gallery/19.jpg" data-size="1000x1500"
-      figure
-        img src="/assets/gallery/thumbs/19.jpg" alt=""
-        figcaption Lorem ipsum Proident do aute cupidatat enim.
-  li.item
-    a href="/assets/gallery/20.jpg" data-size="1000x1500"
-      figure
-        img src="/assets/gallery/thumbs/20.jpg" alt=""
-        figcaption Lorem ipsum Proident do aute cupidatat enim.
-  li.item
-    a href="/assets/gallery/10.jpg" data-size="1500x1000"
-      figure
-        img src="/assets/gallery/thumbs/10.jpg" alt=""
         figcaption Lorem ipsum Proident do aute cupidatat enim.

--- a/assets/targets/components/gallery/01-default-gallery.slim
+++ b/assets/targets/components/gallery/01-default-gallery.slim
@@ -3,12 +3,13 @@ ul.image-gallery
     a href="/assets/gallery/1.jpg" data-size="1500x1000"
       figure
         img src="/assets/gallery/thumbs/1.jpg" alt=""
-        figcaption Lorem ipsum Proident do aute cupidatat enim.
+        p.image-gallery__caption Image with short caption in gallery
+        figcaption Lorem ipsum Duis exercitation dolore pariatur dolore.
   li.item
     a href="/assets/gallery/11.jpg" data-size="1000x1500"
       figure
         img src="/assets/gallery/thumbs/11.jpg" alt=""
-        figcaption Lorem ipsum Mollit elit commodo quis deserunt mollit.
+        figcaption.image-gallery__caption Same caption in gallery as in viewer
   li.item
     a href="/assets/gallery/2.jpg" data-size="1500x1000"
       figure

--- a/assets/targets/components/gallery/02-captions.slim
+++ b/assets/targets/components/gallery/02-captions.slim
@@ -1,0 +1,24 @@
+p You may, and should provide a caption for every image with the <code>figcaption</code> element.
+ul
+  li By default, the caption is shown only in the viewer (cf. first image below).
+  li To show it in the gallery as well, use class <code>image-gallery__caption</code> (cf. second image).
+  li If you need to show a different caption in the gallery than in the viewer, leave the <code>figcaption</code> as is and add a paragraph before it with class <code>image-gallery__caption</code> (cf. third image).
+p.notice.notice--info <strong>Note:</strong> Captions in the gallery should be <strong>concise</strong> and <strong>consistent</strong>&mdash;either provide one for every image, or don't provide any at all.
+
+ul.image-gallery
+  li.item
+    a href="/assets/gallery/10.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/10.jpg" alt=""
+        figcaption No caption in gallery, only in viewer.
+  li.item
+    a href="/assets/gallery/19.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/19.jpg" alt=""
+        figcaption.image-gallery__caption Same caption in gallery as in viewer
+  li.item
+    a href="/assets/gallery/9.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/9.jpg" alt=""
+        p.image-gallery__caption Short caption in gallery
+        figcaption Longer caption in viewer.

--- a/assets/targets/components/gallery/02-small-and-medium.slim
+++ b/assets/targets/components/gallery/02-small-and-medium.slim
@@ -1,0 +1,68 @@
+ul.image-gallery.image-gallery--small
+  li.item
+    a href="/assets/gallery/3.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/3.jpg" alt=""
+        figcaption Lorem ipsum Anim non consequat tempor exercitation ad.
+  li.item
+    a href="/assets/gallery/7.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/7.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/12.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/12.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/21.jpg" data-size="4000x1000"
+      figure
+        img src="/assets/gallery/thumbs/21.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/13.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/13.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/5.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/5.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/14.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/14.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+
+ul.image-gallery.image-gallery--medium
+  li.item
+    a href="/assets/gallery/3.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/3.jpg" alt=""
+        figcaption Lorem ipsum Anim non consequat tempor exercitation ad.
+  li.item
+    a href="/assets/gallery/12.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/12.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/4.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/4.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/21.jpg" data-size="4000x1000"
+      figure
+        img src="/assets/gallery/thumbs/21.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/13.jpg" data-size="1000x1500"
+      figure
+        img src="/assets/gallery/thumbs/13.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.
+  li.item
+    a href="/assets/gallery/5.jpg" data-size="1500x1000"
+      figure
+        img src="/assets/gallery/thumbs/5.jpg" alt=""
+        figcaption Lorem ipsum Proident do aute cupidatat enim.

--- a/assets/targets/components/gallery/03-captions.slim
+++ b/assets/targets/components/gallery/03-captions.slim
@@ -5,11 +5,11 @@ ul
   li If you need to show a different caption in the gallery than in the viewer, leave the <code>figcaption</code> as is and add a paragraph before it with class <code>image-gallery__caption</code> (cf. third image).
 p.notice.notice--info <strong>Note:</strong> Captions in the gallery should be <strong>concise</strong> and <strong>consistent</strong>&mdash;either provide one for every image, or don't provide any at all.
 
-ul.image-gallery
+ul.image-gallery.image-gallery--small
   li.item
-    a href="/assets/gallery/10.jpg" data-size="1500x1000"
+    a href="/assets/gallery/12.jpg" data-size="1000x1500"
       figure
-        img src="/assets/gallery/thumbs/10.jpg" alt=""
+        img src="/assets/gallery/thumbs/12.jpg" alt=""
         figcaption No caption in gallery, only in viewer.
   li.item
     a href="/assets/gallery/19.jpg" data-size="1000x1500"

--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -10,7 +10,7 @@
     float: left; /* float layout while setting up gallery */
     height: 0; /* use padding for responsive ratio */
     list-style-type: none;
-    margin-left: 0;
+    margin: 0;
     max-width: none;
     overflow: hidden;
     padding-bottom: 60%; /* responsive ratio + ensures all items  */

--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -1,28 +1,29 @@
-.uomcontent [role="main"] ul.image-gallery {
+.uomcontent [role="main"] .image-gallery {
+  @include clearfix; /* for float layout while setting up gallery */
   @include rem(max-width, $w-lge);
   padding-left: 0;
   padding-right: 0;
 
   li {
     border: 5px solid transparent;
-    display: inline-block;
-    height: 0;
+    display: block;
+    float: left; /* float layout while setting up gallery */
+    height: 0; /* use padding for responsive ratio */
     list-style-type: none;
-    margin-left: auto;
-    max-width: 200%;
+    margin-left: 0;
+    max-width: none;
     overflow: hidden;
-    padding-bottom: 60%;
-    padding-top: 0;
+    padding-bottom: 60%; /* responsive ratio + ensures all items  */
     position: relative;
+    width: 100%; /* for landscape and panorama ratios */
 
     &.portrait { width: 50%; }
-    &.landscape { width: 100%; }
-    &.panorama { width: 100%; }
 
-    a {
+    & > a {
       background-position: center;
       background-size: cover;
       bottom: 0;
+      color: #fff;
       display: block;
       left: 0;
       margin: 0;
@@ -31,6 +32,7 @@
       top: 0;
       z-index: 0;
 
+      /* overlay with same background image as link for scaling transition on hover */
       &::before {
         background: inherit;
         bottom: 0;
@@ -43,88 +45,90 @@
         z-index: -1;
       }
 
+      /* scale image and show icon + gradient */
       &:hover {
-        &::before {
-          transform: scale(1.1);
-        }
-
-        span {
-          opacity: 1;
-        }
-      }
-
-      figure {
-        margin: 0;
-        padding: 0;
-
-        .image-gallery__caption {
-          @include rem(font-size, 14px);
-          @include rem(padding, 8px 12px);
-          background-color: rgba($black, 0.7);
-          bottom: 0;
-          color: $white;
-          left: 0;
-          line-height: 1.4;
-          position: absolute;
-          right: 0;
-        }
-
-        figcaption:not(.image-gallery__caption) {
-          display: none;
-        }
-      }
-
-      span {
-        background-color: rgba($black, .6);
-        background-image: linear-gradient(to right bottom, rgba(0, 150, 255, .3) 0%, rgba(255, 0, 126, .3) 100%);
-        bottom: 0;
-        cursor: pointer;
-        display: block;
-        left: 0;
-        opacity: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-        transition: opacity 0.3s ease-in-out 0.1s;
-
-        svg {
-          @include rem(height, 40px);
-          @include rem(margin-left, -20px);
-          @include rem(margin-top, -20px);
-          @include rem(width, 40px);
-          fill: $white;
-          left: 50%;
-          position: absolute;
-          top: 50%;
-        }
+        &::before { transform: scale(1.1); }
+        .image-gallery__icon { opacity: 1; }
       }
     }
+  }
 
-    @include breakpoint(desktop) {
-      padding-bottom: 17%;
+  /* zoom icon and purple gradient overlay shown on hover */
+  &__icon {
+    background-color: rgba($black, .6);
+    background-image: linear-gradient(to right bottom, rgba(0, 150, 255, .3) 0%, rgba(255, 0, 126, .3) 100%);
+    bottom: 0;
+    cursor: zoom-in;
+    display: block;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: opacity 0.3s ease-in-out 0.1s;
 
-      &.landscape { width: 25%; }
-      &.portrait { width: 12.5%; }
-      &.panorama { width: 50%; }
+    /* centre icon */
+    & > svg {
+      @include rem(height, 40px);
+      @include rem(margin-left, -20px);
+      @include rem(margin-top, -20px);
+      @include rem(width, 40px);
+      left: 50%;
+      position: absolute;
+      top: 50%;
+    }
+  }
+
+  figure {
+    margin: 0;
+    padding: 0;
+
+    /* caption to be shown in the gallery (can be `figcaption` or a distinct paragraph) */
+    .image-gallery__caption {
+      @include rem(font-size, 14px);
+      @include rem(padding, 8px 12px);
+      background-color: rgba($black, 0.7);
+      bottom: 0;
+      color: #fff;
+      left: 0;
+      line-height: 1.4;
+      position: absolute;
+      right: 0;
+    }
+
+    /* hide figcaption unless it's meant to appear in the gallery */
+    figcaption:not(.image-gallery__caption) {
+      display: none;
     }
   }
 
   img {
+    display: block;
     width: 100%;
+
+    /* hide image with JS when gallery set-up is complete (image becomes link background for cover layout) */
+    &.hide {
+      opacity: 0;
+    }
   }
 
-  /* variant with medium max-width */
-  &--medium {
-    @include rem(max-width, $w-mid);
-
+  @include breakpoint(tablet) {
     li {
-      @include breakpoint(desktop) {
-        padding-bottom: 22.66%;
+      padding-bottom: 34%;
+      width: 50%;
 
-        &.landscape { width: 33.33%; }
-        &.portrait { width: 16.665%; }
-        &.panorama { width: 66.66%; }
-      }
+      &.portrait { width: 25%; }
+      &.panorama { width: 75%; }
+    }
+  }
+
+  @include breakpoint(desktop) {
+    li {
+      padding-bottom: 17%;
+      width: 25%;
+
+      &.portrait { width: 12.5%; }
+      &.panorama { width: 50%; }
     }
   }
 
@@ -132,13 +136,29 @@
   &--small {
     @include rem(max-width, $w-sml);
 
-    li {
-      @include breakpoint(desktop) {
+    /* same as tablet breakpoint without variant */
+    @include breakpoint(desktop) {
+      li {
         padding-bottom: 34%;
+        width: 50%;
 
-        &.landscape { width: 50%; }
         &.portrait { width: 25%; }
         &.panorama { width: 75%; }
+      }
+    }
+  }
+
+  /* variant with medium max-width */
+  &--medium {
+    @include rem(max-width, $w-mid);
+
+    @include breakpoint(desktop) {
+      li {
+        padding-bottom: 22.66%;
+        width: 33.33%;
+
+        &.portrait { width: 16.665%; }
+        &.panorama { width: 66.66%; }
       }
     }
   }

--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -37,10 +37,22 @@
       position: absolute;
       right: 0;
       top: 0;
-      transition: transform 0.2s ease-in-out;
+
+      &::before {
+        background: inherit;
+        bottom: 0;
+        content: '';
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: transform 0.2s ease-in-out;
+      }
 
       &:hover {
-        transform: scale(1.1);
+        &::before {
+          transform: scale(1.1);
+        }
 
         span {
           opacity: 1;

--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -15,17 +15,9 @@
     padding-top: 0;
     position: relative;
 
-    &.portrait {
-      width: 50%;
-    }
-
-    &.landscape {
-      width: 100%;
-    }
-
-    &.panorama {
-      width: 100%;
-    }
+    &.portrait { width: 50%; }
+    &.landscape { width: 100%; }
+    &.panorama { width: 100%; }
 
     a {
       background-position: center;
@@ -111,25 +103,43 @@
     @include breakpoint(desktop) {
       padding-bottom: 17%;
 
-      &.landscape {
-        width: 25%;
-      }
-
-      &.portrait {
-        width: 12.5%;
-      }
-
-      &.square {
-
-      }
-
-      &.panorama {
-        width: 50%;
-      }
+      &.landscape { width: 25%; }
+      &.portrait { width: 12.5%; }
+      &.panorama { width: 50%; }
     }
   }
 
   img {
     width: 100%;
+  }
+
+  /* variant with medium max-width */
+  &--medium {
+    @include rem(max-width, $w-mid);
+
+    li {
+      @include breakpoint(desktop) {
+        padding-bottom: 22.66%;
+
+        &.landscape { width: 33.33%; }
+        &.portrait { width: 16.665%; }
+        &.panorama { width: 66.66%; }
+      }
+    }
+  }
+
+  /* variant with small max-width */
+  &--small {
+    @include rem(max-width, $w-sml);
+
+    li {
+      @include breakpoint(desktop) {
+        padding-bottom: 34%;
+
+        &.landscape { width: 50%; }
+        &.portrait { width: 25%; }
+        &.panorama { width: 75%; }
+      }
+    }
   }
 }

--- a/assets/targets/components/gallery/_gallery.scss
+++ b/assets/targets/components/gallery/_gallery.scss
@@ -37,6 +37,7 @@
       position: absolute;
       right: 0;
       top: 0;
+      z-index: 0;
 
       &::before {
         background: inherit;
@@ -47,6 +48,7 @@
         right: 0;
         top: 0;
         transition: transform 0.2s ease-in-out;
+        z-index: -1;
       }
 
       &:hover {
@@ -57,26 +59,26 @@
         span {
           opacity: 1;
         }
-
-        figcaption {
-          display: none;
-        }
       }
 
       figure {
         margin: 0;
         padding: 0;
 
-        figcaption {
-          @include adjust-font-size-to(14px);
-          @include rem(padding, 5px 10px);
+        .image-gallery__caption {
+          @include rem(font-size, 14px);
+          @include rem(padding, 8px 12px);
           background-color: rgba($black, 0.7);
           bottom: 0;
           color: $white;
-          display: none;
           left: 0;
+          line-height: 1.4;
           position: absolute;
           right: 0;
+        }
+
+        figcaption:not(.image-gallery__caption) {
+          display: none;
         }
       }
 

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -48,7 +48,7 @@ ImageGallery.prototype.setupGallery = function() {
         img = imageLink.querySelector('img'),
         ratio = img.offsetWidth / img.offsetHeight,
         span = document.createElement('span');
-    span.innerHTML = '<svg role="img" class="icon"><use xlink:href="#icon-zoom"></use></svg>';
+    span.innerHTML = '<svg role="img" class="icon"><use xlink:href="#icon-zoom-in"></use></svg>';
     imageLink.parentNode.classList.add(ratio < 1 ? 'portrait' : ratio > 2 ? 'panorama' : 'landscape');
     imageLink.style.backgroundImage = 'url(' + img.src + ')';
     img.classList.add('hidden');

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -8,39 +8,35 @@ function ImageGallery(el, props) {
   this.el = el;
   this.props = props || {};
 
-  this.setupPhotoSwipe();
   this.setupGallery();
+  this.initIsotope();
 
-  new window.Isotope(this.el, {
-    itemSelector: '.item',
-    layoutMode: 'masonry',
-    masonry: {
-      columnWidth: 1,
-      gutter: 0
-    }
-  });
-
-  this.initPhotoSwipeFromDOM();
+  this.setupPhotoSwipe();
+  this.initPhotoSwipe();
 }
 
 /**
- * Set up PhotoSwipe markup
+ * Set up PhotoSwipe markup.
  */
 ImageGallery.prototype.setupPhotoSwipe = function () {
+  // Check if PhotoSwipe viewer has already been set up by another gallery
   this.props.pswp = document.querySelector('.pswp');
-  if (!this.props.pswp) {
-    this.props.pswpEl = document.createElement('div');
-    this.props.pswpEl.className = 'pswp';
-    this.props.pswpEl.setAttribute('tabindex', '-1');
-    this.props.pswpEl.setAttribute('role', 'dialog');
-    this.props.pswpEl.setAttribute('aria-hidden', 'true');
-    this.props.pswpEl.innerHTML = '<div class="pswp__bg"></div><div class="pswp__scroll-wrap"><div class="pswp__container"><div class="pswp__item"></div><div class="pswp__item"></div><div class="pswp__item"></div></div><div class="pswp__ui pswp__ui--hidden"><div class="pswp__top-bar"><div class="pswp__counter"></div><button class="pswp__button pswp__button--close" title="Close (Esc)"></button><button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button><button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button><div class="pswp__preloader"><div class="pswp__preloader__icn"><div class="pswp__preloader__cut"><div class="pswp__preloader__donut"></div></div></div></div></div><div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap"><div class="pswp__share-tooltip"></div></div><button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button><button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button><div class="pswp__caption"><div class="pswp__caption__center"></div></div></div></div>';
-    document.querySelector('.uomcontent').appendChild(this.props.pswpEl);
-  }
+  if (this.props.pswp) return;
+
+  // Inject PhotoSwipe viewer
+  var pswp = document.createElement('div');
+  pswp.className = 'pswp';
+  pswp.setAttribute('tabindex', '-1');
+  pswp.setAttribute('role', 'dialog');
+  pswp.setAttribute('aria-hidden', 'true');
+  pswp.innerHTML = '<div class="pswp__bg"></div><div class="pswp__scroll-wrap"><div class="pswp__container"><div class="pswp__item"></div><div class="pswp__item"></div><div class="pswp__item"></div></div><div class="pswp__ui pswp__ui--hidden"><div class="pswp__top-bar"><div class="pswp__counter"></div><button class="pswp__button pswp__button--close" title="Close (Esc)"></button><button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button><button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button><div class="pswp__preloader"><div class="pswp__preloader__icn"><div class="pswp__preloader__cut"><div class="pswp__preloader__donut"></div></div></div></div></div><div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap"><div class="pswp__share-tooltip"></div></div><button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button><button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button><div class="pswp__caption"><div class="pswp__caption__center"></div></div></div></div>';
+
+  document.querySelector('.uomcontent').appendChild(pswp);
+  this.props.pswp = pswp;
 };
 
 /**
- * Add zoom icon and define aspect
+ * Add hover zoom icon and aspect ratio class to each item.
  */
 ImageGallery.prototype.setupGallery = function () {
   var items = this.el.querySelectorAll('li');
@@ -53,6 +49,8 @@ ImageGallery.prototype.setupGallery = function () {
 
     item.classList.add(ratio < 1 ? 'portrait' : (ratio > 2 ? 'panorama' : 'landscape'));
     link.style.backgroundImage = 'url(' + img.src + ')';
+    link.setAttribute('data-pswp-uid', i + 1);
+    link.addEventListener('click', this.onThumbnailClick.bind(this, i));
     img.classList.add('hide');
 
     var icon = document.createElement('span');
@@ -62,97 +60,24 @@ ImageGallery.prototype.setupGallery = function () {
   }
 };
 
-ImageGallery.prototype.initPhotoSwipeFromDOM = function() {
-  var gallerySelector = this.el;
-
-  var parseThumbnailElements = function(el) {
-    var thumbElements = el.childNodes,
-      numNodes = thumbElements.length,
-      items = [],
-      figureEl,
-      linkEl,
-      liEl,
-      size,
-      item;
-
-    for (var i = 0; i < numNodes; i++) {
-      liEl = thumbElements[i];
-      if (liEl.nodeType !== 1) {
-        continue;
-      }
-
-      linkEl = liEl.children[0]; // <a> element
-      figureEl = linkEl.children[0];
-
-      size = linkEl.getAttribute('data-size').split('x');
-
-      // create slide object
-      item = {
-        src: linkEl.getAttribute('href'),
-        w: parseInt(size[0], 10),
-        h: parseInt(size[1], 10)
-      };
-
-      if (figureEl.children.length > 1) {
-        // <figcaption> content
-        item.title = figureEl.querySelector('figcaption').innerHTML;
-        item.msrc = figureEl.querySelector('img').getAttribute('src');
-      }
-
-      item.el = liEl; // save link to element for getThumbBoundsFn
-      items.push(item);
+/**
+ * Initialise masonry layout.
+ */
+ImageGallery.prototype.initIsotope = function () {
+  this.props.isotope = new window.Isotope(this.el, {
+    itemSelector: '.item',
+    layoutMode: 'masonry',
+    masonry: {
+      columnWidth: 1,
+      gutter: 0
     }
+  });
+};
 
-    return items;
-  };
-
-  var closest = function closest(el, fn) {
-      return el && ( fn(el) ? el : closest(el.parentNode, fn) );
-  };
-
-  var onThumbnailsClick = function(e) {
-    e = e || window.event;
-    if (typeof e.preventDefault !=="undefined")
-      e.preventDefault();
-    else
-      e.returnValue = false;
-
-    // find root element of slide
-    var clickedListItem = closest(this, function(el) {
-      return (el.tagName && el.tagName.toUpperCase() === 'LI');
-    });
-
-    if (!clickedListItem) {
-      return;
-    }
-
-    // find index of clicked item by looping through all child nodes
-    // alternatively, you may define index via data- attribute
-    var clickedGallery = clickedListItem.parentNode,
-      childNodes = clickedListItem.parentNode.childNodes,
-      numChildNodes = childNodes.length,
-      nodeIndex = 0,
-      index;
-
-    for (var i = 0; i < numChildNodes; i++) {
-      if (childNodes[i].nodeType !== 1) {
-        continue;
-      }
-
-      if (childNodes[i] === clickedListItem) {
-        index = nodeIndex;
-        break;
-      }
-      nodeIndex++;
-    }
-
-    if (index >= 0) {
-      // open PhotoSwipe if valid index found
-      openPhotoSwipe( index, clickedGallery );
-    }
-    return false;
-  };
-
+/**
+ * Initialise PhotoSwipe.
+ */
+ImageGallery.prototype.initPhotoSwipe = function() {
   var photoswipeParseHash = function() {
     var hash = window.location.hash.substring(1),
     params = {};
@@ -184,54 +109,89 @@ ImageGallery.prototype.initPhotoSwipeFromDOM = function() {
     return params;
   };
 
-  var openPhotoSwipe = function(index, galleryElement, disableAnimation) {
-    var pswpElement = document.querySelectorAll('.pswp')[0],
-      gallery,
-      options,
-      items;
-
-    items = parseThumbnailElements(galleryElement);
-
-    // define options (if needed)
-    options = {
-      index: index,
-      showHideOpacity: true,
-
-      // define gallery index (for URL)
-      galleryUID: galleryElement.getAttribute('data-pswp-uid'),
-
-      // define boundaries of thumbnail for animation
-      getThumbBoundsFn: function(index) {
-        var thumbnail = items[index].el.querySelector('a');
-        var rect = thumbnail.getBoundingClientRect();
-        return {
-          x: rect.left,
-          y: rect.top + window.pageYOffset,
-          w: rect.width
-        };
-      }
-    };
-
-    if (disableAnimation) {
-      options.showAnimationDuration = 0;
-    }
-
-    // Pass data to PhotoSwipe and initialize it
-    gallery = new PhotoSwipe( pswpElement, PhotoSwipeUI_Default, items, options);
-    gallery.init();
-  };
-
-  var galleryElements = gallerySelector.querySelectorAll('a');
-
-  for(var i = 0, l = galleryElements.length; i < l; i++) {
-    galleryElements[i].setAttribute('data-pswp-uid', i+1);
-    galleryElements[i].onclick = onThumbnailsClick;
-  }
+  var galleryElements = this.el.querySelectorAll('a');
 
   var hashData = photoswipeParseHash();
   if (hashData.pid > 0 && hashData.gid > 0) {
-    openPhotoSwipe( hashData.pid - 1 ,  galleryElements[ hashData.gid - 1 ], true );
+    this.openPhotoSwipe(hashData.pid - 1, galleryElements[hashData.gid - 1], true);
   }
+};
+
+ImageGallery.prototype.onThumbnailClick = function (index, evt) {
+  evt.preventDefault();
+  console.log(this);
+  this.openPhotoSwipe(index, this.el);
+};
+
+ImageGallery.prototype.openPhotoSwipe = function (index, galleryElement, disableAnimation) {
+  var items = this.parseThumbnailElements(galleryElement);
+
+  var options = {
+    index: index,
+    showHideOpacity: true,
+
+    // define gallery index (for URL)
+    galleryUID: galleryElement.getAttribute('data-pswp-uid'),
+
+    // define boundaries of thumbnail for animation
+    getThumbBoundsFn: function(index) {
+      var thumbnail = items[index].el.querySelector('a');
+      var rect = thumbnail.getBoundingClientRect();
+      return {
+        x: rect.left,
+        y: rect.top + window.pageYOffset,
+        w: rect.width
+      };
+    }
+  };
+
+  if (disableAnimation) {
+    options.showAnimationDuration = 0;
+  }
+
+  this.props.gallery = new PhotoSwipe(this.props.pswp, window.PhotoSwipeUI_Default, items, options);
+  this.props.gallery.init();
+};
+
+ImageGallery.prototype.parseThumbnailElements = function (el) {
+  var thumbElements = el.childNodes,
+    numNodes = thumbElements.length,
+    items = [],
+    figureEl,
+    linkEl,
+    liEl,
+    size,
+    item;
+
+  for (var i = 0; i < numNodes; i++) {
+    liEl = thumbElements[i];
+    if (liEl.nodeType !== 1) {
+      continue;
+    }
+
+    linkEl = liEl.children[0]; // <a> element
+    figureEl = linkEl.children[0];
+
+    size = linkEl.getAttribute('data-size').split('x');
+
+    // create slide object
+    item = {
+      src: linkEl.getAttribute('href'),
+      w: parseInt(size[0], 10),
+      h: parseInt(size[1], 10)
+    };
+
+    if (figureEl.children.length > 1) {
+      // <figcaption> content
+      item.title = figureEl.querySelector('figcaption').innerHTML;
+      item.msrc = figureEl.querySelector('img').getAttribute('src');
+    }
+
+    item.el = liEl; // save link to element for getThumbBoundsFn
+    items.push(item);
+  }
+
+  return items;
 };
 
 module.exports = ImageGallery;

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -26,7 +26,7 @@ function ImageGallery(el, props) {
 /**
  * Set up PhotoSwipe markup
  */
-ImageGallery.prototype.setupPhotoSwipe = function() {
+ImageGallery.prototype.setupPhotoSwipe = function () {
   this.props.pswp = document.querySelector('.pswp');
   if (!this.props.pswp) {
     this.props.pswpEl = document.createElement('div');
@@ -35,31 +35,34 @@ ImageGallery.prototype.setupPhotoSwipe = function() {
     this.props.pswpEl.setAttribute('role', 'dialog');
     this.props.pswpEl.setAttribute('aria-hidden', 'true');
     this.props.pswpEl.innerHTML = '<div class="pswp__bg"></div><div class="pswp__scroll-wrap"><div class="pswp__container"><div class="pswp__item"></div><div class="pswp__item"></div><div class="pswp__item"></div></div><div class="pswp__ui pswp__ui--hidden"><div class="pswp__top-bar"><div class="pswp__counter"></div><button class="pswp__button pswp__button--close" title="Close (Esc)"></button><button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button><button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button><div class="pswp__preloader"><div class="pswp__preloader__icn"><div class="pswp__preloader__cut"><div class="pswp__preloader__donut"></div></div></div></div></div><div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap"><div class="pswp__share-tooltip"></div></div><button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button><button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button><div class="pswp__caption"><div class="pswp__caption__center"></div></div></div></div>';
-    document.querySelector('div.uomcontent').appendChild(this.props.pswpEl);
+    document.querySelector('.uomcontent').appendChild(this.props.pswpEl);
   }
 };
 
 /**
- * Add zoom icon, define aspect
+ * Add zoom icon and define aspect
  */
-ImageGallery.prototype.setupGallery = function() {
-  for (var imageLinks = this.el.querySelectorAll('li a'), i=imageLinks.length - 1; i >= 0; i--) {
-    var imageLink = imageLinks[i],
-        img = imageLink.querySelector('img'),
-        ratio = img.offsetWidth / img.offsetHeight,
-        span = document.createElement('span');
-    span.innerHTML = '<svg role="img" class="icon"><use xlink:href="#icon-zoom-in"></use></svg>';
-    imageLink.parentNode.classList.add(ratio < 1 ? 'portrait' : ratio > 2 ? 'panorama' : 'landscape');
-    imageLink.style.backgroundImage = 'url(' + img.src + ')';
-    img.classList.add('hidden');
-    imageLink.appendChild(span);
+ImageGallery.prototype.setupGallery = function () {
+  var items = this.el.querySelectorAll('li');
+  for (var i = items.length - 1; i >= 0; i--) {
+    var item = items[i];
+
+    var link = item.querySelector('a');
+    var img = item.querySelector('img');
+    var ratio = img.offsetWidth / img.offsetHeight;
+
+    item.classList.add(ratio < 1 ? 'portrait' : (ratio > 2 ? 'panorama' : 'landscape'));
+    link.style.backgroundImage = 'url(' + img.src + ')';
+    img.classList.add('hide');
+
+    var icon = document.createElement('span');
+    icon.className = 'image-gallery__icon';
+    icon.innerHTML = '<svg role="img" class="icon"><use xlink:href="#icon-zoom-in"></use></svg>';
+    link.appendChild(icon);
   }
 };
 
 ImageGallery.prototype.initPhotoSwipeFromDOM = function() {
-  // var PhotoSwipe = require('photoswipe');
-  // var PhotoSwipeUI_Default = require('photoswipe/dist/photoswipe-ui-default'); // missing assets?
-
   var gallerySelector = this.el;
 
   var parseThumbnailElements = function(el) {

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -7,16 +7,9 @@ function ImageGallery(el, props) {
   this.el = el;
   this.props = props || {};
 
+  this.props.gid = this.props.index || 0
   this.props.items = el.querySelectorAll('li');
   this.props.slides = [];
-
-  this.props.pswpDefaults = {
-    showHideOpacity: true,
-    // define gallery index (for URL)
-    galleryUID: this.props.index || 0,
-    // define boundaries of thumbnail for animation
-    getThumbBoundsFn: this.getThumbBoundsFn.bind(this)
-  };
 
   this.setupGallery();
   this.initIsotope();
@@ -111,7 +104,7 @@ ImageGallery.prototype.restoreFromHash = function () {
   if (!matches || matches.length !== 3) return;
 
   // Return if GID doesn't refer to this gallery instance
-  if (parseInt(matches[1], 10) !== this.props.pswpDefaults.galleryUID) return;
+  if (parseInt(matches[1], 10) !== this.props.gid) return;
 
   // Open viewer to specified slide
   var index = parseInt(matches[2], 10);
@@ -134,10 +127,13 @@ ImageGallery.prototype.onThumbnailClick = function (index, evt) {
  * @param {Boolean} disableAnimation - set to `true` when restoring from UL hash
  */
 ImageGallery.prototype.openPhotoSwipe = function (slideIndex, disableAnimation) {
-  var options = Object.assign({}, this.props.pswpDefaults, {
+  var options = {
+    galleryUID: this.props.gid,
+    getThumbBoundsFn: this.getThumbBoundsFn.bind(this),
     index: slideIndex,
-    showAnimationDuration: disableAnimation ? 0 : 333
-  });
+    showAnimationDuration: disableAnimation ? 0 : 333,
+    showHideOpacity: true
+  };
 
   var gallery = new PhotoSwipe(this.props.pswp, window.PhotoSwipeUI_Default, this.props.slides, options);
   gallery.init();

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -195,16 +195,20 @@ ImageGallery.prototype.initPhotoSwipeFromDOM = function() {
     // define options (if needed)
     options = {
       index: index,
+      showHideOpacity: true,
 
       // define gallery index (for URL)
       galleryUID: galleryElement.getAttribute('data-pswp-uid'),
 
+      // define boundaries of thumbnail for animation
       getThumbBoundsFn: function(index) {
-        // See Options -> getThumbBoundsFn section of documentation for more info
-        var thumbnail = items[index].el.getElementsByTagName('a')[0], // find thumbnail
-          pageYScroll = window.pageYOffset || document.documentElement.scrollTop,
-          rect = thumbnail.getBoundingClientRect();
-        return {x:rect.left, y:rect.top + pageYScroll + 20, w:rect.width};
+        var thumbnail = items[index].el.querySelector('a');
+        var rect = thumbnail.getBoundingClientRect();
+        return {
+          x: rect.left,
+          y: rect.top + window.pageYOffset,
+          w: rect.width
+        };
       }
     };
 

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -92,8 +92,8 @@ ImageGallery.prototype.initPhotoSwipeFromDOM = function() {
 
       if (figureEl.children.length > 1) {
         // <figcaption> content
-        item.title = figureEl.children[1].innerHTML;
-        item.msrc = figureEl.children[0].getAttribute('src');
+        item.title = figureEl.querySelector('figcaption').innerHTML;
+        item.msrc = figureEl.querySelector('img').getAttribute('src');
       }
 
       item.el = liEl; // save link to element for getThumbBoundsFn

--- a/assets/targets/components/gallery/index.scss
+++ b/assets/targets/components/gallery/index.scss
@@ -6,3 +6,8 @@
 .pswp img {
   max-width: none;
 }
+
+.pswp__caption__center {
+  @include rem(max-width, $w-sml);
+  text-align: center;
+}

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -79,7 +79,7 @@ window.UOMloadComponents = function() {
   "use strict";
 
   var recs, i, g, SidebarTabs, JumpNav, CheckboxHelper, FancySelect, Flash, FilteredListing,
-    ImageGallery, imagesLoaded, slingshot, style, script, keyscript;
+    ImageGallery, slingshot, style, script, keyscript;
 
   window.UOMbind('accordion');
   window.UOMbind('modal');

--- a/assets/targets/components/index.js
+++ b/assets/targets/components/index.js
@@ -154,7 +154,7 @@ window.UOMloadComponents = function() {
       .then(function (recs) {
         ImageGallery = require("./gallery");
         for (i=recs.length - 1; i >= 0; i--)
-          new ImageGallery(recs[i], {});
+          new ImageGallery(recs[i], { index: i });
       }.bind(null, recs));
   }
 

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -123,21 +123,14 @@ window.DSComponentsLoad = function() {
   recs = document.querySelectorAll('ul.image-gallery');
   if (recs.length > 0) {
     window.loadScript([
-      'https://d2h9b02ioca40d.cloudfront.net/shared/photoswipe.pkgd.min.js',
+      'https://unpkg.com/photoswipe@4.1.1/dist/photoswipe.min.js',
+      'https://unpkg.com/photoswipe@4.1.1/dist/photoswipe-ui-default.min.js',
       'https://unpkg.com/isotope-layout@3.0/dist/isotope.pkgd.min.js'
     ])
       .then(function (recs) {
-        imagesLoaded = require('imagesloaded');
         ImageGallery = require("../components/gallery");
-
-        slingshot = function (g) {
-          new ImageGallery(g);
-        };
-
-        for (i=recs.length - 1; i >= 0; i--) {
-          g = recs[i];
-          imagesLoaded(g, slingshot.bind(null, g));
-        }
+        for (i=recs.length - 1; i >= 0; i--)
+          new ImageGallery(recs[i], { index: i });
       }.bind(null, recs));
   }
 

--- a/assets/targets/debranded/index.js
+++ b/assets/targets/debranded/index.js
@@ -21,7 +21,7 @@ window.DSComponentsLoad = function() {
 
   var recs, i, g, Accordion, Modal, Tabs, SidebarTabs, InpageNavigation,
     JumpNav, CheckboxHelper, UnlockChecklist, FancySelect, ValidateForm,
-    FilteredListing, IconHelper, ImageGallery, imagesLoaded, slingshot, LMaps,
+    FilteredListing, IconHelper, ImageGallery, slingshot, LMaps,
     style, script, CreateNameSpace, Icons;
 
   CreateNameSpace = require('../../shared/createnamespace');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,16 +17,6 @@
       "from": "es6-promise@>=4.0.5 <5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz"
     },
-    "ev-emitter": {
-      "version": "1.0.3",
-      "from": "ev-emitter@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.0.3.tgz"
-    },
-    "imagesloaded": {
-      "version": "4.1.1",
-      "from": "imagesloaded@>=4.1.1 <4.2.0",
-      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.1.tgz"
-    },
     "just-debounce": {
       "version": "1.0.0",
       "from": "just-debounce@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "classlist-polyfill": "^1.0.2",
     "es6-promise": "^4.0.5",
-    "imagesloaded": "~4.1.1",
     "just-debounce": "^1.0.0",
     "normalize.css": "^5.0.0",
     "perfect-scrollbar": "^0.6.10",


### PR DESCRIPTION
Big revamp of the gallery component: code clean-up, performance improvements, bug fixes and new features.

- Fix #671 - allow showing an image's caption in the gallery listing with class `image-gallery__caption`. The class can be added to:
  - the `figcaption` element in order to show the same caption in the gallery as in the viewer,
  - a separate paragraph element in order to show a different, shorter caption in the gallery.
- Fix #733 - add variant classes for small and medium-width galleries: `image-gallery--small` and `image-gallery--medium`.
- Fix zoom icon on hover, and change cursor to `zoom-in`
- Centre captions in viewer
- Fix animation on open/close:
  - improve performance by not triggering a reflow, and
  - fix jankyness by fixing thumbnail bounds computation and enabling opacity animation
- Fix initial layout while gallery is loading
- Fix masonry layout in IE9
- Fix history restoration: re-open viewer when navigating back after leaving the gallery page with the viewer open, or when visiting a URL with a PhotoSwipe hash (e.g. `#&gid=0&pid=1`). Note that changing the hash while on the page doesn't do anything at this point (i.e. there's no `onhashchange` event handler).
- Clean up and refactor code
- Update documentation