### PR TITLE
Add logo listing

### DIFF
--- a/assets/targets/components/listings/17-logo-listing.slim
+++ b/assets/targets/components/listings/17-logo-listing.slim
@@ -1,0 +1,14 @@
+.logo-listing
+  figure.logo-listing__item
+    img alt="" src="http://placeimg.com/110/180/animals"
+    figcaption Label
+  img.logo-listing__item alt="" src="http://placeimg.com/190/50"
+  img.logo-listing__item alt="" src="http://placeimg.com/230/120/animals"
+  img.logo-listing__item alt="" src="http://placeimg.com/130/130/animals"
+  a.logo-listing__item href="#"
+    figure
+      img alt="" src="http://placeimg.com/60/230/animals"
+      figcaption Another label
+  a.logo-listing__item href="#"
+    img alt="" src="http://placeimg.com/130/130"
+  img.logo-listing__item alt="" src="http://placeimg.com/130/130/animals"

--- a/assets/targets/components/listings/_logo.scss
+++ b/assets/targets/components/listings/_logo.scss
@@ -1,0 +1,25 @@
+.logo-listing {
+  @include rem(max-width, $w-mid);
+  margin: 0 auto;
+  text-align: center;
+
+  &__item {
+    @include rem(padding, 10px);
+    color: rgba($black, .8);
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  figcaption {
+    font-size: .8em;
+  }
+
+  figure {
+    margin: 0;
+    text-decoration: inherit;
+  }
+
+  li {
+    list-style-type: none;
+  }
+}

--- a/assets/targets/components/listings/index.scss
+++ b/assets/targets/components/listings/index.scss
@@ -4,3 +4,4 @@
 @import 'block';
 @import 'nav_text';
 @import 'nav_block';
+@import 'logo';


### PR DESCRIPTION
Create new listing for vertically aligned display of logos, as per doc example:

![screen shot 2017-02-13 at 5 27 59 pm](https://cloud.githubusercontent.com/assets/863542/22873159/3372ad42-f212-11e6-8fec-7700a10f56d0.png)

- Fix #801 
- Fix #698