### PR TITLE
Fix bold regression

### DIFF
--- a/assets/shared/_normalize.scss
+++ b/assets/shared/_normalize.scss
@@ -29,6 +29,12 @@ li {
   box-sizing: border-box;
 }
 
+// Override `bolder` from normalize.css, as Roboto's default font-weight is 300, and 400 isn't bold-enough
+b,
+strong {
+  font-weight: bold;
+}
+
 // Override normalize.css behaviour
 button,
 input,


### PR DESCRIPTION
Override `bolder` for `b and `strong` introduced by `normalize.css`. The design system's default font-weight is 300 for Roboto, and Roboto's 400 weight is not bold enough.