### PR TITLE
Refactor local nav and make `inner` wrappers optional

### DIFF
--- a/assets/shared/_normalize.scss
+++ b/assets/shared/_normalize.scss
@@ -65,3 +65,13 @@ iframe[src^='//player.vimeo.com'] {
 .wf-loading * {
   font-family: -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif;
 }
+
+// Chrome-less button for UI interactions
+.button-ui {
+  background: none transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+}

--- a/assets/shared/_normalize.scss
+++ b/assets/shared/_normalize.scss
@@ -40,6 +40,10 @@ textarea {
   line-height: inherit;
 }
 
+button:not([disabled]) {
+  cursor: pointer;
+}
+
 iframe[src^='//www.youtube.com'],
 iframe[src^='//player.vimeo.com'] {
   width: 100%;

--- a/assets/targets/components/buttons/_buttons.scss
+++ b/assets/targets/components/buttons/_buttons.scss
@@ -343,14 +343,4 @@
       @include rem(font-size, 16px);
     }
   }
-
-  // Chrome-less button for UI interactions
-  .button-ui {
-    background: none transparent;
-    border: 0;
-    color: inherit;
-    font: inherit;
-    margin: 0;
-    padding: 0;
-  }
 }

--- a/assets/targets/components/modal/_modal.scss
+++ b/assets/targets/components/modal/_modal.scss
@@ -51,7 +51,6 @@
   .modal__close {
     background-color: #fff;
     color: $midgray;
-    cursor: pointer;
     font-size: 11px;
     font-weight: 400;
     padding: 0 0 5px 5px;

--- a/assets/targets/components/tabs/_tabs.scss
+++ b/assets/targets/components/tabs/_tabs.scss
@@ -198,7 +198,6 @@
       @include rem(padding, 0 20px 5px); // bottom padding aligns arrows with tab labels
       background: $darkblue;
       color: $white;
-      cursor: pointer;
       display: none;
       font-weight: $bold;
       height: 100%;
@@ -207,7 +206,6 @@
       z-index: 2;
 
       &[disabled] {
-        cursor: default;
         opacity: .5;
       }
 

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -1,10 +1,6 @@
 @keyframes chevronback {
-  0% {
-    transform: translateX(0);
-  }
-  50% {
-    transform: translateX(-5px);
-  }
+  0% { transform: translateX(0); }
+  50% { transform: translateX(-5px); }
 }
 
 .uomcontent [role="navigation"]#sitemap {
@@ -55,19 +51,6 @@
       }
     }
   }
-
-  .w {
-    @include rem(padding-right, $width-sitemap-trigger);
-    height: 100%;
-    overflow-x: hidden;
-    overflow-y: auto;
-
-    @include breakpoint(tablet) {
-      @include rem(width, $width-localnav);
-      padding-right: 0;
-    }
-  }
-
 
   ul {
     margin: 0;
@@ -141,28 +124,29 @@
     margin-left: 0;
     padding: 0;
     width: auto;
-
-    &:first-child {
-      border-top: 0;
-    }
   }
 
   .localnav__close {
     @include rem(font-size, 12px);
+    @include rem(padding, 20px);
     background-color: darken($menu, 3%);
     color: $lightblue;
     color: rgba($white, .6);
-    font-weight: 400;
+    display: block;
+    font-weight: normal;
     line-height: 1.96;
+    letter-spacing: .07em;
+    text-align: left;
     text-transform: uppercase;
+    width: 100%;
 
     &:before {
       @include rem(font-size, 20px);
+      @include rem(padding-right, 10px);
       content: '\2039';
       float: left;
-      font-weight: $regular;
+      font-weight: normal;
       line-height: 1;
-      padding-right: 10px;
     }
 
     &:hover,

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -196,9 +196,7 @@
     }
   }
 
-  .parent {
-    cursor: pointer;
-
+  .localnav__nested-trigger {
     &:after {
       @include rem(font-size, 24px);
       content: '\203a';

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -1,137 +1,46 @@
-@keyframes chevronback {
-  0% { transform: translateX(0); }
-  50% { transform: translateX(-5px); }
-}
-
-.uomcontent [role="navigation"]#sitemap {
-  @include normalise;
-  background-color: $menu;
-  color: $white;
+/**
+ * Local navigation
+ */
+.uomcontent .localnav {
   font-family: $ff-sans;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding-right: $width-sitemap-trigger;
+  color: #fff;
   position: fixed;
-  right: -100%;
-  top: 0;
-  transform: translateX(0);
-  transition: $smooth-transform;
-  width: 100%;
   z-index: 15;
 
-  * {
-    @include normalise;
-  }
-
-  &.active {
-    box-shadow: 1px 0 12px 3px rgba($black, .6);
-    transform: translateX(-100%);
-
-    .sitemap-trigger {
-      margin-left: -100px;
-    }
-
-    &.inner-open {
-      overflow: hidden;
-    }
-  }
-
-  @include breakpoint(tablet) {
-    margin-right: $width-sitemap-trigger;
-    padding-right: 0;
-    right: $offset-localnav;
-    width: $width-localnav;
-
-    &.active {
-      transform: translateX($offset-localnav);
-
-      .sitemap-trigger {
-        margin-left: 0;
-      }
-    }
-  }
-
-  ul {
-    margin: 0;
-    padding: 0;
-
-    &.meta {
-      @include rem(padding, 20px 0);
-      border-top: 1px solid darken($borderblue, 30%);
-      border-top: 1px solid rgba($white, .1);
-
-      li {
-        border-top: none;
-      }
-
-      a {
-        @include rem(font-size, 13px);
-        @include rem(line-height, 24px);
-        @include rem(padding, 2px 20px);
-        color: #8ca2b8;
-        color: rgba($white, .7);
-
-        &:hover,
-        &:focus {
-          background-color: transparent;
-          color: $white;
-        }
-
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
-  }
-
-  .inner {
-    background-color: $navy;
+  &__panel {
+    @include rem(padding-right, $width-sitemap-trigger);
+    background-color: $menu;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    padding-right: $width-sitemap-trigger;
-    position: absolute;
     right: -100%;
     top: 0;
     transform: translateX(0);
     transition: $smooth-transform;
     width: 100%;
 
-    &.active {
+    &--nested {
+      position: absolute;
+    }
+
+    /* hide sidebar of parent panels */
+    &--nested-open {
+      overflow: hidden;
+    }
+
+    /* show panel */
+    &--open {
       transform: translateX(-100%);
     }
-
-    li {
-      background-color: $navy;
-    }
-
-    @include breakpoint(tablet) {
-      padding-right: 0;
-    }
   }
 
-  img {
-    display: none;
-    margin: 0 25%;
-    max-width: 50%;
-  }
-
-  li {
-    border-top: 1px solid darken($borderblue, 30%);
-    border-top: 1px solid rgba($white, .1);
-    list-style-type: none;
-    margin-left: 0;
-    padding: 0;
-    width: auto;
-  }
-
-  .localnav__close {
+  /* close and back buttons */
+  &__close-btn,
+  &__back-btn {
     @include rem(font-size, 12px);
     @include rem(padding, 20px);
     background-color: darken($menu, 3%);
-    color: $lightblue;
-    color: rgba($white, .6);
+    color: rgba(255, 255, 255, .6);
     display: block;
     font-weight: normal;
     line-height: 1.96;
@@ -140,7 +49,7 @@
     text-transform: uppercase;
     width: 100%;
 
-    &:before {
+    &::before {
       @include rem(font-size, 20px);
       @include rem(padding-right, 10px);
       content: '\2039';
@@ -151,37 +60,17 @@
 
     &:hover,
     &:focus {
-      color: $white;
+      color: inherit;
 
-      &:before {
-        animation: chevronback 1s infinite ease-in-out;
+      &::before {
+        animation: chevron-left 1s infinite ease-in-out;
       }
     }
-
-    &--back {
-      background-color: $menu;
-    }
   }
 
-  a,
-  span {
-    @include rem(font-size, 14px);
-    @include rem(letter-spacing, 1px);
-    @include rem(padding, 20px);
-    color: $white;
-    display: block;
-    outline-offset: -1px;
-    text-decoration: none;
-
-    &:hover,
-    &:focus {
-      background-color: darken($menu, 3%);
-      color: $white;
-    }
-  }
-
-  .localnav__nested-trigger {
-    &:after {
+  /* add chevron to nested panel triggers */
+  &__nested-trigger {
+    &::after {
       @include rem(font-size, 24px);
       content: '\203a';
       float: right;
@@ -190,13 +79,105 @@
       z-index: 9;
     }
   }
+
+  /* overrides for all lists */
+  &__list,
+  &__meta {
+    color: inherit;
+    margin: 0;
+    max-width: none;
+
+    & > li {
+      color: inherit;
+      display: block;
+      list-style-type: none;
+      margin: 0;
+      max-width: none;
+      padding: 0;
+      width: auto;
+    }
+
+    a {
+      @include rem(letter-spacing, 1px);
+      color: inherit;
+      display: block;
+      outline-offset: -1px;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: $white;
+      }
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  /* root and nested nav lists */
+  &__list {
+    border-bottom: 1px solid rgba(255, 255, 255, .1);
+    padding: 0;
+
+    & > li {
+      border-top: 1px solid rgba(255, 255, 255, .1);
+    }
+
+    a {
+      @include rem(font-size, 14px);
+      @include rem(padding, 20px);
+
+      &:hover,
+      &:focus {
+        background-color: darken($menu, 3%);
+        color: $white;
+      }
+    }
+  }
+
+  /* meta menu */
+  &__meta {
+    @include rem(padding, 20px 0);
+    color: rgba(255, 255, 255, .7);
+
+    a {
+      @include rem(font-size, 13px);
+      @include rem(padding, 4px 20px);
+    }
+  }
+
+  /* show local nav */
+  &.active {
+    transform: translateX(-100%);
+  }
+
+  @include breakpoint(tablet) {
+    /* switch to fixed width */
+    @include rem(right, $offset-localnav);
+    @include rem(width, $width-localnav);
+
+    /* now that width is fixed, switch to margin so that sitemap link doesn't hide panel scrollbars */
+    @include rem(margin-right, $width-sitemap-trigger);
+    &__panel { padding-right: 0; }
+
+    &.active {
+      box-shadow: 1px 0 12px 3px rgba(0, 0, 0, .6);
+      transform: translateX($offset-localnav);
+    }
+  }
+
+  .no-js & {
+    @include wrapper;
+    background-color: $navy;
+    box-shadow: 0 0 0;
+    display: block;
+    position: static;
+    width: auto;
+  }
 }
 
-.no-js .uomcontent [role="navigation"]#sitemap {
-  @include wrapper;
-  background-color: $navy;
-  box-shadow: 0 0 0;
-  display: block;
-  position: static;
-  width: auto;
+@keyframes chevron-left {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(-5px); }
 }

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -35,12 +35,11 @@
   }
 
   /* close and back buttons */
-  &__close-btn,
   &__back-btn {
     @include rem(font-size, 12px);
     @include rem(padding, 20px);
     background-color: darken($menu, 3%);
-    color: rgba(255, 255, 255, .6);
+    color: rgba(255, 255, 255, .7);
     display: block;
     font-weight: normal;
     line-height: 1.96;
@@ -66,6 +65,10 @@
         animation: chevron-left 1s infinite ease-in-out;
       }
     }
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   /* add chevron to nested panel triggers */
@@ -74,7 +77,7 @@
       @include rem(font-size, 24px);
       content: '\203a';
       float: right;
-      font-weight: $regular;
+      font-weight: 400;
       line-height: .85;
       z-index: 9;
     }
@@ -106,7 +109,7 @@
 
       &:hover,
       &:focus {
-        color: $white;
+        color: #fff;
       }
 
       &:hover {
@@ -131,7 +134,7 @@
       &:hover,
       &:focus {
         background-color: darken($menu, 3%);
-        color: $white;
+        color: #fff;
       }
     }
   }

--- a/assets/targets/injection/nav/_localnav.scss
+++ b/assets/targets/injection/nav/_localnav.scss
@@ -157,6 +157,10 @@
         animation: chevronback 1s infinite ease-in-out;
       }
     }
+
+    &--back {
+      background-color: $menu;
+    }
   }
 
   a,
@@ -173,26 +177,6 @@
     &:focus {
       background-color: darken($menu, 3%);
       color: $white;
-    }
-  }
-
-  .back {
-    background-color: $menu;
-    color: $lightblue;
-    color: rgba($white, .6);
-    cursor: pointer;
-
-    &:before {
-      @include rem(font-size, 24px);
-      content: '\2039';
-      float: left;
-      font-weight: $regular;
-      line-height: .85;
-      padding-right: 10px;
-    }
-
-    &:hover:before {
-      animation: chevronback 1s infinite ease-in-out;
     }
   }
 

--- a/assets/targets/injection/nav/_modal.scss
+++ b/assets/targets/injection/nav/_modal.scss
@@ -46,7 +46,6 @@
 
   .modal__close {
     color: $midgray;
-    cursor: pointer;
     font-size: 11px;
     font-weight: 400;
     position: absolute;

--- a/assets/targets/injection/nav/index.es6
+++ b/assets/targets/injection/nav/index.es6
@@ -54,7 +54,7 @@ InjectNav.prototype.setupEventBindings = function() {
     this.props.menuTrigger.addEventListener('click', this.openLocalNav.bind(this));
 
     // Local nav close button
-    this.props.localNav.querySelector('.localnav__close').addEventListener('click', this.closeLocalNav.bind(this));
+    this.props.localNav.querySelector('.localnav__close-btn').addEventListener('click', this.closeLocalNav.bind(this));
 
     // Close local nav when selecting internal links (except close button)
     for (var triggers = this.props.localNav.querySelectorAll('a'), i=triggers.length - 1; i > 0; i--) {

--- a/assets/targets/injection/nav/index.es6
+++ b/assets/targets/injection/nav/index.es6
@@ -28,16 +28,11 @@ function InjectNav(props) {
   for (var prop in elements) { this.props[prop] = elements[prop]; }
 
   // Set up a blanket object
-  this.props.blanket = new Blanket({
-    root: this.props.root
-  });
+  this.props.blanket = new Blanket({ root: this.props.root });
 
   // Set up local nav
   if (this.props.localNav) {
-    new LocalNav({
-      root: this.props.root,
-      localnav: this.props.localNav
-    });
+    new LocalNav(this.props.localNav, { root: this.props.root });
   }
 
   // Inialise nav state, render global sitemap and bind events

--- a/assets/targets/injection/nav/index.es6
+++ b/assets/targets/injection/nav/index.es6
@@ -32,7 +32,11 @@ function InjectNav(props) {
 
   // Set up local nav
   if (this.props.localNav) {
-    new LocalNav(this.props.localNav, { root: this.props.root });
+    this.props.localNavInstance = new LocalNav(this.props.localNav, {
+      root: this.props.root,
+      closeLocalNav: this.closeLocalNav.bind(this),
+      openGlobalNav: this.openGlobalNav.bind(this)
+    });
   }
 
   // Inialise nav state, render global sitemap and bind events
@@ -50,36 +54,17 @@ InjectNav.prototype.setActiveNav = function(state) {
 };
 
 InjectNav.prototype.setupEventBindings = function() {
-  // Local nav is defined
-  if (this.props.localNav && this.props.menuTrigger) {
-    this.props.menuTrigger.addEventListener('click', this.openLocalNav.bind(this));
-
-    // Local nav close button
-    this.props.localNav.querySelector('.localnav__close-btn').addEventListener('click', this.closeLocalNav.bind(this));
-
-    // Close local nav when selecting internal links (except close button)
-    for (var triggers = this.props.localNav.querySelectorAll('a'), i=triggers.length - 1; i > 0; i--) {
-      if (triggers[i].getAttribute('href').indexOf('#') != -1) {
-        triggers[i].addEventListener('click', this.closeLocalNav.bind(this));
-      }
-    }
-
-    this.props.sitemapTrigger.addEventListener('click', this.openGlobalNav.bind(this));
-
-    this.props.localSitemapTrigger = this.props.localNav.querySelector('.sitemap-link');
-    if (this.props.localSitemapTrigger) {
-      this.props.localSitemapTrigger.addEventListener('click', this.openGlobalNav.bind(this));
-    }
-
-  } else if (this.props.menuTrigger) {
-    this.props.menuTrigger.addEventListener('click', this.openGlobalNav.bind(this));
-  }
-
+  this.props.sitemapTrigger.addEventListener('click', this.openGlobalNav.bind(this));
   this.props.globalNav.querySelector('.close-button').addEventListener('click', this.closeGlobalNav.bind(this));
   this.props.blanket.el.addEventListener('click', this.closeBothNavs.bind(this));
 
   if (this.props.searchTrigger) {
     this.props.searchTrigger.addEventListener('click', this.handleSearchTrigger.bind(this));
+  }
+
+  if (this.props.menuTrigger) {
+    var menuHandler = this.props.localNavInstance ? this.openLocalNav : this.openGlobalNav;
+    this.props.menuTrigger.addEventListener('click', menuHandler.bind(this));
   }
 
   // Restore nav states when user navigates back/forward

--- a/assets/targets/injection/nav/index.es6
+++ b/assets/targets/injection/nav/index.es6
@@ -36,13 +36,14 @@ function InjectNav(props) {
   }
 
   // Inialise nav state, render global sitemap and bind events
-  this.setActiveNav();
+  this.setActiveNav(this.props.supportsHistory ? window.history.state : null);
   this.renderGlobalSitemap();
   this.setupEventBindings();
+  this.update();
 }
 
 InjectNav.prototype.setActiveNav = function(state) {
-  this.props.activeNav = (state ? state : {
+  this.props.activeNav = (state && state[HISTORY_KEY] ? state[HISTORY_KEY] : {
     local: false,
     global: false
   });
@@ -84,8 +85,7 @@ InjectNav.prototype.setupEventBindings = function() {
   // Restore nav states when user navigates back/forward
   if (this.props.supportsHistory) {
     window.addEventListener('popstate', function(e) {
-      var newState = e.state && e.state[HISTORY_KEY] ? e.state[HISTORY_KEY] : null;
-      this.setActiveNav(newState);
+      this.setActiveNav(e.state);
       this.update();
     }.bind(this));
   }

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -40,9 +40,9 @@ LocalNav.prototype.initLocalNav = function () {
 
   // Inject close button
   var closeBtn = document.createElement('button');
-  closeBtn.setAttribute('type', 'button');
   closeBtn.className = 'localnav__close button-ui';
   closeBtn.textContent = 'Close';
+  closeBtn.setAttribute('type', 'button');
   this.el.insertBefore(closeBtn, rootMenu);
 
   // Move local nav to root container
@@ -96,11 +96,12 @@ LocalNav.prototype.initNestedMenu = function (item) {
   trigger.addEventListener('click', this.toggleNestedMenu.bind(this, nestedMenu, true));
 
   // Inject button to close nested menu
-  var back = document.createElement('span');
-  back.className = 'back';
-  back.textContent = trigger.textContent;
-  back.addEventListener('click', this.toggleNestedMenu.bind(this, nestedMenu, false));
-  nestedMenu.insertBefore(back, nestedList);
+  var backBtn = document.createElement('button');
+  backBtn.className = 'localnav__close localnav__close--back button-ui';
+  backBtn.textContent = trigger.textContent;
+  backBtn.setAttribute('type', 'button');
+  backBtn.addEventListener('click', this.toggleNestedMenu.bind(this, nestedMenu, false));
+  nestedMenu.insertBefore(backBtn, nestedList);
 };
 
 /**

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -6,38 +6,42 @@
  */
 function LocalNav(el, props) {
   this.el = el;
+  this.props = props;
 
   // Don't initialise local nav twice
   if (this.el.hasAttribute('data-bound')) return;
   this.el.setAttribute('data-bound', true);
 
-  this.props = props;
-  this.props.rootMenu = this.el.querySelector('h2 + ul');
-  this.props.metaMenu = this.el.querySelector('ul.meta');
-  this.props.absRootPath = this.el.getAttribute('data-absolute-root') || '/';
-
-  this.moveLocalNav();
+  this.initLocalNav();
   this.initMetaMenu();
   this.initNestedMenus();
 }
 
-LocalNav.prototype.moveLocalNav = function () {
-  // Retrieve nav title and remove from DOM
-  var navtitle = this.el.querySelector('h2');
-  navtitle.parentNode.removeChild(navtitle);
+/**
+ * Initialise local nav and move it to the root container of the page.
+ */
+LocalNav.prototype.initLocalNav = function () {
+  var rootMenu = this.el.querySelector('ul'); // first `ul`
+  var absRootPath = this.el.getAttribute('data-absolute-root') || '/';
 
-  // Make nav title a list item instead
-  var firstli = document.createElement('li');
-  firstli.className = 'home';
-  firstli.innerHTML = `<a href="${this.props.absRootPath}">${(navtitle.textContent)}</a>`;
-  this.props.rootMenu.insertBefore(firstli, this.props.rootMenu.firstChild);
+  // Retrieve nav title and remove it from the DOM
+  var title = this.el.querySelector('h2');
+  title.parentNode.removeChild(title);
 
-  // Create and insert close button
-  var closeli = document.createElement('li');
-  closeli.innerHTML = '<a href="#" class="localnav__close">Close</a>';
-  this.props.rootMenu.insertBefore(closeli, firstli);
+  // Inject item with link to homepage
+  var homeItem = document.createElement('li');
+  homeItem.className = 'home';
+  homeItem.innerHTML = `<a href="${absRootPath}">${(title.textContent)}</a>`;
+  rootMenu.insertBefore(homeItem, rootMenu.firstChild);
 
-  // Move local nav outside page container
+  // Inject close button
+  var closeBtn = document.createElement('button');
+  closeBtn.setAttribute('type', 'button');
+  closeBtn.className = 'localnav__close button-ui';
+  closeBtn.textContent = 'Close';
+  this.el.insertBefore(closeBtn, rootMenu);
+
+  // Move local nav to root container
   this.props.root.appendChild(this.el);
 };
 
@@ -45,16 +49,16 @@ LocalNav.prototype.moveLocalNav = function () {
  * Initialise meta menu.
  */
 LocalNav.prototype.initMetaMenu = function () {
-  var metaMenu = this.props.metaMenu;
+  var metaMenu = this.el.querySelector('ul.meta');
 
-  // Create meta menu if it doesn't exist
+  // Create meta menu if it doesn't already exist
   if (!metaMenu) {
-    metaMenu = this.props.metaMenu = document.createElement('ul');
+    metaMenu = document.createElement('ul');
     metaMenu.className = 'meta';
     this.el.appendChild(metaMenu);
   }
 
-  // Inject link to sitemap if it doesn't exist
+  // Inject list item with link to sitemap if it doesn't already exist
   if (!metaMenu.querySelector('a.sitemap-link')) {
     var sitemapItem = document.createElement('li');
     sitemapItem.innerHTML = '<a class="sitemap-link" href="https://unimelb.edu.au/sitemap">Browse University</a>';

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -1,85 +1,99 @@
 /**
- * LocalNav
- *
+ * Local navigation
+ * @param  {Element} el
  * @param  {Object} props
  */
-function LocalNav(props) {
+function LocalNav(el, props) {
+  this.el = el;
   this.props = props;
+
   this.moveLocalNav();
+  this.initNestedLists();
 }
 
-LocalNav.prototype.moveLocalNav = function() {
+LocalNav.prototype.moveLocalNav = function () {
+  if (this.el.querySelector('a.sitemap-link')) return;
+
   // Move local nav outside page container
-  if (!this.props.localnav.querySelector('a.sitemap-link')) {
-    var rootmenu, lastmenu, noderoot;
+  var rootmenu, lastmenu, noderoot;
 
-    // Check for deprecated markup
-    noderoot = this.props.localnav.querySelector('.w');
-    if (!noderoot)
-      noderoot = this.props.localnav;
+  // Check for deprecated markup
+  noderoot = this.el.querySelector('.w');
+  if (!noderoot)
+    noderoot = this.el;
 
-    for (var recs=noderoot.childNodes, max=recs.length, i=0; i < max; i++) {
-      if (recs[i].nodeType == 1 && recs[i].nodeName == 'UL') {
-        lastmenu = recs[i];
-        if (rootmenu === undefined)
-          rootmenu = recs[i];
-      }
-    }
-    var absroot = (this.props.localnav.getAttribute('data-absolute-root') || '/');
-
-    // Retrieve nav title and remove from DOM
-    var navtitle = noderoot.querySelector('h2');
-    navtitle.parentNode.removeChild(navtitle); // Remove from parent if out of order
-
-    // Make nav title a list item instead
-    var firstli = document.createElement('li');
-    firstli.className = 'home';
-    firstli.innerHTML = `<a href="${absroot}">${(navtitle.textContent)}</a>`;
-    rootmenu.insertBefore(firstli, rootmenu.firstChild);
-
-    // Create and insert close button
-    var closeli = document.createElement('li');
-    closeli.innerHTML = '<a href="#" class="localnav__close">Close</a>';
-    rootmenu.insertBefore(closeli, firstli);
-
-    // Create inner link to sitemap
-    if (lastmenu == rootmenu) {
-      lastmenu = document.createElement('ul');
-      lastmenu.className = 'meta';
-      noderoot.appendChild(lastmenu);
-    }
-
-    var lastli = document.createElement('li');
-    lastli.innerHTML = '<a class="sitemap-link" href="https://unimelb.edu.au/sitemap">Browse University</a>';
-    lastmenu.appendChild(lastli);
-
-    this.props.root.appendChild(this.props.localnav);
-
-    var innerElements = this.props.localnav.querySelectorAll('.inner');
-    var innerElem, parent, back, handler;
-
-    for (i = innerElements.length - 1; i >= 0; i--) {
-      innerElem = innerElements[i];
-      handler = toggleActive.bind(this, innerElem);
-
-      parent = innerElem.parentNode.querySelector('a');
-      parent.classList.add('parent');
-      parent.addEventListener('click', handler);
-
-      back = document.createElement('span');
-      back.className = 'back';
-      back.innerHTML = parent.textContent;
-      back.addEventListener('click', handler);
-      innerElem.insertBefore(back, innerElem.firstChild);
-    }
-
-    function toggleActive(elem, evt) {
-      evt.preventDefault();
-      elem.classList.toggle('active');
-      this.props.localnav.scrollTop = 0;
-      this.props.localnav.classList.toggle('inner-open');
+  for (var recs=noderoot.childNodes, max=recs.length, i=0; i < max; i++) {
+    if (recs[i].nodeType == 1 && recs[i].nodeName == 'UL') {
+      lastmenu = recs[i];
+      if (rootmenu === undefined)
+        rootmenu = recs[i];
     }
   }
+  var absroot = (this.el.getAttribute('data-absolute-root') || '/');
+
+  // Retrieve nav title and remove from DOM
+  var navtitle = noderoot.querySelector('h2');
+  navtitle.parentNode.removeChild(navtitle); // Remove from parent if out of order
+
+  // Make nav title a list item instead
+  var firstli = document.createElement('li');
+  firstli.className = 'home';
+  firstli.innerHTML = `<a href="${absroot}">${(navtitle.textContent)}</a>`;
+  rootmenu.insertBefore(firstli, rootmenu.firstChild);
+
+  // Create and insert close button
+  var closeli = document.createElement('li');
+  closeli.innerHTML = '<a href="#" class="localnav__close">Close</a>';
+  rootmenu.insertBefore(closeli, firstli);
+
+  // Create inner link to sitemap
+  if (lastmenu == rootmenu) {
+    lastmenu = document.createElement('ul');
+    lastmenu.className = 'meta';
+    noderoot.appendChild(lastmenu);
+  }
+
+  var lastli = document.createElement('li');
+  lastli.innerHTML = '<a class="sitemap-link" href="https://unimelb.edu.au/sitemap">Browse University</a>';
+  lastmenu.appendChild(lastli);
+
+  this.props.root.appendChild(this.el);
+};
+
+/**
+ * Initialise nested lists.
+ */
+LocalNav.prototype.initNestedLists = function () {
+  var nestedLists = this.el.querySelectorAll('.inner');
+  var list, link, back;
+
+  for (i = nestedLists.length - 1; i >= 0; i--) {
+    list = nestedLists[i];
+
+    link = list.parentNode.querySelector('a');
+    link.classList.add('parent');
+
+    back = document.createElement('span');
+    back.className = 'back';
+    back.innerHTML = link.textContent;
+    list.insertBefore(back, list.firstChild);
+
+    link.addEventListener('click', this.toggleNestedList.bind(this, list, true));
+    back.addEventListener('click', this.toggleNestedList.bind(this, list, false));
+  }
+};
+
+/**
+ * Open/close a nested navigation list.
+ * @param  {Element} list
+ * @param  {Boolean} open
+ * @param  {Event} evt
+ */
+LocalNav.prototype.toggleNestedList = function (list, open, evt) {
+  evt.preventDefault();
+  list.classList.toggle('active', open);
+  this.el.scrollTop = 0;
+  this.el.classList.toggle('inner-open');
 };
 
 module.exports = LocalNav;

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -3,6 +3,8 @@
  * @param  {Element} el
  * @param  {Object} props
  *         {Element} root - the root element of the page with class `uomcontent`
+ *         {Function} closeLocalNav
+ *         {Function} openGlobalNav
  */
 function LocalNav(el, props) {
   this.el = el;
@@ -17,6 +19,7 @@ function LocalNav(el, props) {
 
   this.initLocalNav();
   this.initMetaMenu();
+  this.initInternalLinks();
 
   // Loop through all list items (including nested items) to initialise nested panels
   var items = [].slice.call(this.props.rootList.querySelectorAll('li'));
@@ -47,6 +50,7 @@ LocalNav.prototype.initLocalNav = function () {
   closeBtn.className = 'localnav__close-btn button-ui';
   closeBtn.textContent = 'Close';
   closeBtn.setAttribute('type', 'button');
+  closeBtn.addEventListener('click', this.props.closeLocalNav);
   this.el.insertBefore(closeBtn, this.props.rootList);
 
   // Move local nav to root container
@@ -57,7 +61,7 @@ LocalNav.prototype.initLocalNav = function () {
  * Initialise meta menu.
  */
 LocalNav.prototype.initMetaMenu = function () {
-  var metaMenu = this.el.querySelector('ul.meta');
+  var metaMenu = this.el.querySelector('.meta');
 
   // Create meta menu if it doesn't already exist
   if (!metaMenu) {
@@ -69,12 +73,24 @@ LocalNav.prototype.initMetaMenu = function () {
   // Add custom class to meta menu
   metaMenu.classList.add('localnav__meta');
 
-  // Inject list item with link to sitemap if it doesn't already exist
-  if (!metaMenu.querySelector('a.sitemap-link')) {
-    var sitemapItem = document.createElement('li');
-    sitemapItem.innerHTML = '<a class="sitemap-link" href="https://unimelb.edu.au/sitemap">Browse University</a>';
-    metaMenu.appendChild(sitemapItem);
-  }
+  // Inject list item with link to sitemap
+  var sitemapItem = document.createElement('li');
+  sitemapItem.innerHTML = '<a href="https://unimelb.edu.au/sitemap">Browse University</a>';
+  metaMenu.appendChild(sitemapItem);
+
+  // Open global nav when newly created sitemap link is clicked
+  var sitemapLink = sitemapItem.querySelector('a');
+  sitemapLink.addEventListener('click', this.props.openGlobalNav);
+};
+
+/**
+ * Close local nav when an internal link is clicked.
+ */
+LocalNav.prototype.initInternalLinks = function () {
+  var internalLinks = [].slice.call(this.el.querySelectorAll('a[href^="#"]'));
+  internalLinks.forEach(function (link) {
+    link.addEventListener('click', this.props.closeLocalNav);
+  }, this);
 };
 
 /**

--- a/assets/targets/injection/nav/localnav.es6
+++ b/assets/targets/injection/nav/localnav.es6
@@ -47,7 +47,7 @@ LocalNav.prototype.initLocalNav = function () {
 
   // Inject close button
   var closeBtn = document.createElement('button');
-  closeBtn.className = 'localnav__close-btn button-ui';
+  closeBtn.className = 'localnav__back-btn button-ui';
   closeBtn.textContent = 'Close';
   closeBtn.setAttribute('type', 'button');
   closeBtn.addEventListener('click', this.props.closeLocalNav);

--- a/views/_nav.slim
+++ b/views/_nav.slim
@@ -8,4 +8,4 @@
             == nav_item[:title]
 
     ul.meta
-      li: a href="https://github.com/marcom-unimelb/unimelb-design-system/issues" Report an Issue
+      li: a href="https://github.com/marcom-unimelb/unimelb-design-system/issues" Report an issue

--- a/views/_nav.slim
+++ b/views/_nav.slim
@@ -4,8 +4,43 @@
     ul
       - opts[:navigation].each do |nav_item|
         li
-          a href=(nav_item[:href])
-            == nav_item[:title]
+          a href=(nav_item[:href]) == nav_item[:title]
+
+      / Nested menus for testing purposes (de-indent to enable)
+        li
+          a href="" Nested inner L1
+          .inner
+            ul
+              li: a href="" Foo
+              li: a href="" Bar
+              li
+                a href="" Nested inner L2
+                .inner
+                  ul
+                    li: a href="" Foo
+                    li: a href="" Bar
+              li
+                a href="" Nested list L2
+                ul
+                  li: a href="" Foo
+                  li: a href="" Bar
+        li
+          a href="" Nested list L1
+          ul
+            li: a href="" Foo
+            li: a href="" Bar
+            li
+              a href="" Nested list L2
+              ul
+                li: a href="" Foo
+                li: a href="" Bar
+            li
+              a href="" Nested inner L2
+              .inner
+                ul
+                  li: a href="" Foo
+                  li: a href="" Bar
+
 
     ul.meta
       li: a href="https://github.com/marcom-unimelb/unimelb-design-system/issues" Report an issue

--- a/views/_nav.slim
+++ b/views/_nav.slim
@@ -11,7 +11,7 @@
           a href="" Nested inner L1
           .inner
             ul
-              li: a href="" Foo
+              li: a href="#intro" Internal link
               li: a href="" Bar
               li
                 a href="" Nested inner L2
@@ -40,7 +40,6 @@
                 ul
                   li: a href="" Foo
                   li: a href="" Bar
-
 
     ul.meta
       li: a href="https://github.com/marcom-unimelb/unimelb-design-system/issues" Report an issue

--- a/views/pages/getting-started.slim.md
+++ b/views/pages/getting-started.slim.md
@@ -62,7 +62,7 @@ section
 
   p To integrate a local nav into your site, include the following structure after the <code>div role="main"</code>.
 
-  p For nested navigation, use a <code>div class="inner"</code> as demonstrated below.
+  p For nested navigation, use a <code>div class="inner"</code> as demonstrated below. You can have multiple levels of nesting, but this is not recommended. If your system doesn't allow you to add <code>inner</code> containers, you may omit them and just use nested lists.
 
 pre: code.html
   ==convert_tags


### PR DESCRIPTION
Fixes #773 - `inner` wrappers can now be omitted in the [local nav markup](http://web.unimelb.edu.au/getting-started/#local-nav), in which case they are injected automatically. Note that this does have a very small impact on performance, so if you're able to provide the wrappers yourself, please do so.

This PR also includes a complete refactoring of the `LocalNav` component. Below is a non-exhaustive list of the changes:

- use `button` rather than `span` for close/back buttons
- add BEM classes on the fly in order to clean-up the CSS and reduce the number of overridden styles
- make nested panels look the same as the root panel
- underline links on hover
- move event bindings for local nav elements out of the `InjectedNav` component and into the `LocalNav` component (pass  required functions as props)
- split local nav code into separate methods to improve code readability
- add loads of comments
- fix deeply nested panels with regard to vertical overflow, by keeping track of which panels are open at any given time
- add nested panels to the doc site's localnav for testing purposes (commented-out)