### PR TITLE
Meta info for search results

### DIFF
--- a/assets/shared/_vars.scss
+++ b/assets/shared/_vars.scss
@@ -2,6 +2,7 @@
 $black:         #000 !default;
 $darkgray:      #333;
 $midgray:       #666;
+$midgrayer:     #777; /* last accessible gray on white background */
 $gray:          #adb8c1;
 $lightgray:     #f6f6f6;
 $lightergray:   #e0e0e0;

--- a/assets/targets/components/search/02-search-results.slim
+++ b/assets/targets/components/search/02-search-results.slim
@@ -10,13 +10,24 @@ h2.search-title All results
 ol.search-results
   li
     h3
-      a href="#" Bachelor of Science Extended — Course Search · The Universit...
+      a href="" Accelerated Mathematics
+    dl.search-results__meta
+      dt> Year:
+      dd 2017
+      dt> Type:
+      dd Breadth track
     p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
     p.url
       a href="http://science.unimelb.edu.au/" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
   li
     h3
-      a href="#" Breadth Requirements for the Bachelor of Science : Breadth...
+      a href="" Bachelor of Science Extended — Course Search · The Universit...
+    p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
+    p.url
+      a href="http://science.unimelb.edu.au/" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
+  li
+    h3
+      a href="" Breadth Requirements for the Bachelor of Science : Breadth...
     p
       span.icon--hide-label> data-icon="lock" Secure result
       | Bachelor of Science students complete a breadth component of 50 points (four subjects), with another 25 points (two subjects) of free (that is, breadth or core) ...
@@ -25,22 +36,22 @@ ol.search-results
   li
     img src="/assets/example/tsinghua_university.jpg" alt="Tsinghua University"
     h3
-      a href="#" School of Social and Political Sciences | Political Science
+      a href="" School of Social and Political Sciences | Political Science
     p Political science explores the main issues, ideas, institutions and actors that dominate local, national and international politics. It focuses on how people engage ...
     p.url
       a href="http://science.unimelb.edu.au/" ssps.unimelb.edu.au/study-areas/political-science
   li
     img src="http://open.mapquestapi.com/staticmap/v4/getmap?size=130,130&zoom=14&center=-37.79894,144.96073&scalebar=false&pois=blue,-37.79894,144.96073&key=Fmjtd%7Cluur2l6r2u%2C7a%3Do5-90ywlw" alt="Map of Parville campus"
     h3
-      a href="#" Parkville Campus : Maps
+      a href="" Parkville Campus : Maps
     p Maps. Maps Parkville. Parkville Campus. ... Gates. Burnley; Creswick; Dookie; Shepparton; Southbank; Werribee. Maps. More maps and information are available. ...
     p.url
       a href="http://science.unimelb.edu.au/" maps.unimelb.edu.au/parkville
     p.more
-      a href="#" More results from maps.unimelb.edu.au
+      a href="" More results from maps.unimelb.edu.au
   li
     h3
-      a href="#" History and Philosophy of Science
+      a href="" History and Philosophy of Science
     p History and Philosophy of Science (HPS) is a unique discipline in the Faculty of Arts, which brings together perspectives from the history of science and medicine  ...
     p.url
       a href="http://science.unimelb.edu.au/" shaps.unimelb.edu.au/history-philosophy-science
@@ -49,7 +60,7 @@ ol.search-results
     .person__info
       .person__profile
         h3
-          a href="#" Chaz Batrouney
+          a href="" Chaz Batrouney
         p: em Web Producer
         p Project Services
       .person__contact
@@ -60,7 +71,7 @@ ol.search-results
     .person__info
       .person__profile
         h3
-          a href="#" Chaz Batrouney
+          a href="" Chaz Batrouney
         p: em Web Producer
         p Project Services
       .person__contact
@@ -68,7 +79,7 @@ ol.search-results
         p.person__email: a href="mailto:chaz-batrouney@unimelb.edu.au" chaz-batrouney@unimelb.edu.au
   li
     h3
-      a href="#" Master of Food Science — Faculty of Veterinary and Agriculture ...
+      a href="" Master of Food Science — Faculty of Veterinary and Agriculture ...
     p Investigate the interdisciplinary nature of agriculture, food production and food science at an advanced level; Strengthen your food chemistry, microbiology, ...
     p.url
       a href="http://science.unimelb.edu.au/" fvas.unimelb.edu.au/study/courses/master-of-food-science

--- a/assets/targets/components/search/_search-results.scss
+++ b/assets/targets/components/search/_search-results.scss
@@ -162,4 +162,32 @@
       }
     }
   }
+
+  /* Definition list for meta information (e.g. year/type for handbook results) */
+  .search-results__meta {
+    @include rem(font-size, 14px);
+    @include rem(margin, -4px 0 2px);
+    padding: 0;
+
+    & > dt,
+    & > dd {
+      display: inline-block;
+      float: none;
+    }
+
+    & > dt {
+      color: $midgrayer;
+      clear: none;
+      width: auto;
+    }
+
+    & > dd {
+      margin-left: 0;
+    }
+
+    /* space out consecutive items */
+    & > dd + dt {
+      margin-left: 1rem;
+    }
+  }
 }


### PR DESCRIPTION
Allow adding a definition list below a search result's heading to display meta information, like the year and type for a handbook search result.

<img width="825" alt="screen shot 2017-03-06 at 10 04 45 am" src="https://cloud.githubusercontent.com/assets/2936402/23592663/8abf12d8-0258-11e7-8f3c-2642b0d84e02.png">
