### PR TITLE
Track design system version

### DIFF
--- a/assets/targets/injection/tealium/index.js
+++ b/assets/targets/injection/tealium/index.js
@@ -1,8 +1,19 @@
 (function(root) {
   var utag_data = {};
+
+  // Track design system version
+  var uomScript = document.querySelector('script[src$="uom.js"]');
+  if (uomScript) {
+    var uomVersion = /\/v([0-9]+\.[0-9]+(?:\.[0-9]+)?)\/uom\.js$/.exec(uomScript.src);
+    utag_data.uom_version = uomVersion.length >= 2 ? uomVersion[1] : 'cannot-parse-version';
+  } else {
+    utag_data.uom_version = 'script-not-found';
+  }
+
+  // Load Tealium
   (function(a,b,c,d){
     a='//tags.tiqcdn.com/utag/unimelb/main/prod/utag.js';
     b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true;
     a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a);
-    })();
+  })();
 })(this);


### PR DESCRIPTION
Looks for the `uom.js` script, parses the version number from the `src` and pass it to Tealium via `utag_data`.

This will allow us to see which versions are no longer used, and which sites are still using old versions and need to be updated.