### PR TITLE
Fix various block listing issues

### DIFF
--- a/assets/targets/components/block-listing/00-overview.md
+++ b/assets/targets/components/block-listing/00-overview.md
@@ -1,3 +1,5 @@
 ---
 title: Block listing
 ---
+
+Use this tile-based listing to share news, events and social media posts from Instagram and Twitter.

--- a/assets/targets/components/block-listing/01-block-listing.slim
+++ b/assets/targets/components/block-listing/01-block-listing.slim
@@ -1,4 +1,4 @@
-p Use this tile-based listing to share news, events and social media posts from Instagram and Twitter.
+p Inside the basic <em>news</em>, <em>event</em>, and <em>exhibition</em> tiles, images should be provided as background images on an empty element with class <code>block-listing__img</code>, and have a ratio of 16/9 (56.25%). If you don't have a choice but to use <code>img</code> tags, make sure to wrap them inside containers with class <code>crop-height</code> in order to approximate the background-image behaviour.
 
 ul.block-listing
   li.event.double.newshero.special style="background-image: url(http://placeimg.com/740/320/any?5);"
@@ -14,9 +14,8 @@ ul.block-listing
         time datetime="2014-03-18" 18 March
         time datetime="2014-05-04" 4 May 2014
       .mid-unit
-        strong Sed natum conceptam porro iuvaret sensibus quo ad constituam in 2014
-      .crop-height
-        img alt="" src="http://placeimg.com/740/320/animals"
+        strong Sed natum conceptam porro iuvaret sensibus quo ad constituam in mnesarchum. Sed porro iuvaret in, per eu natum conceptam.
+      .block-listing__img style="background-image: url(http://placeimg.com/740/620/animals);"
       .meta
         em.meta-right Event
   li.instagram style="background-image: url(http://placeimg.com/400/600/any?5);"
@@ -28,8 +27,7 @@ ul.block-listing
           |@unimelb
   li.news
     a.block-container href=""
-      .crop-height
-        img alt="" src="http://placeimg.com/640/320/any?1"
+      .block-listing__img style="background-image: url(http://placeimg.com/740/620/any?1);"
       strong International law. Is it myth or reality?
       p The fate of boat people in the Indian Ocean and the Mediterranean proves attitudes are hardening.
       .meta
@@ -43,7 +41,7 @@ ul.block-listing
           a href="#" @unimelb
   li.news
     a.block-container href=""
-      img alt="" src="http://placeimg.com/740/320/any?3"
+      .block-listing__img style="background-image: url(http://placeimg.com/740/320/any?3);"
       strong Multi-party Government the way of future
       p It used to be a once-in-a-lifetime moment, but it’s set to become the norm as voters hedge their bets.
       .meta
@@ -55,9 +53,9 @@ ul.block-listing
         time datetime="2014-05-28"  28 May 2014
         | 5:00 pm - 1:00 am
       .mid-unit
-        strong Dunc audiam aliquam eu sed
+        strong This tile uses an <code>img</code> tag inside a <code>crop-height</code> container instead of a background image.
       .crop-height
-        img alt="" src="http://placeimg.com/640/320/nature"
+        img alt="" src="http://placeimg.com/674/380/nature"
       .meta
         em.meta-right Exhibition
   li.news.no-anim

--- a/assets/targets/components/block-listing/01-block-listing.slim
+++ b/assets/targets/components/block-listing/01-block-listing.slim
@@ -1,5 +1,7 @@
 p Inside the basic <em>news</em>, <em>event</em>, and <em>exhibition</em> tiles, images should be provided as background images on an empty element with class <code>block-listing__img</code>, and have a ratio of 16/9 (56.25%). If you don't have a choice but to use <code>img</code> tags, make sure to wrap them inside containers with class <code>crop-height</code> in order to approximate the background-image behaviour.
 
+p If a tile doesn't have a link (i.e. if <code>block-container</code> is a <code>div</code> rather than an anchor), use class <code>no-anim</code> to remove the hover effect.
+
 ul.block-listing
   li.event.double.newshero.special style="background-image: url(http://placeimg.com/740/320/any?5);"
     a.block-container href=""
@@ -41,9 +43,10 @@ ul.block-listing
           a href="#" @unimelb
   li.news
     a.block-container href=""
-      .block-listing__img style="background-image: url(http://placeimg.com/740/320/any?3);"
+      .crop-height
+        img alt="" src="http://placeimg.com/740/320/any?3"
       strong Multi-party Government the way of future
-      p It used to be a once-in-a-lifetime moment, but it’s set to become the norm as voters hedge their bets.
+      p This tile uses an <code>img</code> tag inside a <code>crop-height</code> container instead of a background image. The image appears shorter because it has a wider ratio than 16/9, so this technique should be avoided.
       .meta
         em Politics & Society
   li.exhibition
@@ -60,9 +63,9 @@ ul.block-listing
         em.meta-right Exhibition
   li.news.no-anim
     .block-container
-      strong Cu idque nulla eos, modus sensibus constituam et quo. Ne mel duis simul, quo ad euismod partiendo
+      strong This is an example of a tile without a link
       p Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum.
-      p Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum.
+      p Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Dicunt audiam aliquam eu sed, te mei decore maiorum.
       .meta
         time.meta-left datetime="2015-02-30"  30 Feb 2015
         em.meta-right News

--- a/assets/targets/components/block-listing/01-block-listing.slim
+++ b/assets/targets/components/block-listing/01-block-listing.slim
@@ -9,7 +9,7 @@ ul.block-listing
           br
           |Why today’s children need more than a good night’s sleep.
   li.event
-    .block-container
+    a.block-container href=""
       .top-unit
         .when.range
           time datetime="2014-03-18" 18 March
@@ -49,7 +49,7 @@ ul.block-listing
       .meta
         em Politics & Society
   li.exhibition
-    .block-container
+    a.block-container href=""
       .top-unit
         .when
           | Wednesday

--- a/assets/targets/components/block-listing/01-block-listing.slim
+++ b/assets/targets/components/block-listing/01-block-listing.slim
@@ -84,7 +84,6 @@ ul.block-listing
           ' @unimelb
   li.event.double style=("background-image: url(http://placeimg.com/680/590/arch);")
     a.block-container href=""
-      .top-unit
-        strong Apeirian nominati partiendo
-        p Ullum ornatus intellegam in sea
-        span.button-hero-inverse href=""  Call to Action
+      strong Apeirian nominati partiendo
+      p Ullum ornatus intellegam in sea
+      span.button-hero-inverse href=""  Call to Action

--- a/assets/targets/components/block-listing/01-block-listing.slim
+++ b/assets/targets/components/block-listing/01-block-listing.slim
@@ -10,14 +10,13 @@ ul.block-listing
           |Why today’s children need more than a good night’s sleep.
   li.event
     a.block-container href=""
-      .top-unit
-        .when.range
-          time datetime="2014-03-18" 18 March
-          time datetime="2014-05-04" 4 May 2014
-        .mid-unit
-          strong Sed natum conceptam porro iuvaret sensibus quo ad constituam in 2014
-        .crop-height
-          img alt="" src="http://placeimg.com/740/320/animals"
+      .when.range
+        time datetime="2014-03-18" 18 March
+        time datetime="2014-05-04" 4 May 2014
+      .mid-unit
+        strong Sed natum conceptam porro iuvaret sensibus quo ad constituam in 2014
+      .crop-height
+        img alt="" src="http://placeimg.com/740/320/animals"
       .meta
         em.meta-right Event
   li.instagram style="background-image: url(http://placeimg.com/400/600/any?5);"
@@ -29,7 +28,8 @@ ul.block-listing
           |@unimelb
   li.news
     a.block-container href=""
-      img alt="" src="http://placeimg.com/740/320/any?1"
+      .crop-height
+        img alt="" src="http://placeimg.com/640/320/any?1"
       strong International law. Is it myth or reality?
       p The fate of boat people in the Indian Ocean and the Mediterranean proves attitudes are hardening.
       .meta
@@ -50,23 +50,21 @@ ul.block-listing
         em Politics & Society
   li.exhibition
     a.block-container href=""
-      .top-unit
-        .when
-          | Wednesday
-          time datetime="2014-05-28"  28 May 2014
-          | 5:00 pm - 1:00 am
-        .mid-unit
-          strong Dunc audiam aliquam eu sed
-        .crop-height
-          img alt="" src="http://placeimg.com/640/320/nature"
+      .when
+        | Wednesday
+        time datetime="2014-05-28"  28 May 2014
+        | 5:00 pm - 1:00 am
+      .mid-unit
+        strong Dunc audiam aliquam eu sed
+      .crop-height
+        img alt="" src="http://placeimg.com/640/320/nature"
       .meta
         em.meta-right Exhibition
   li.news.no-anim
     .block-container
-      .top-unit
-        strong Cu idque nulla eos, modus sensibus constituam et quo. Ne mel duis simul, quo ad euismod partiendo
-        p Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum.
-        p Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum.
+      strong Cu idque nulla eos, modus sensibus constituam et quo. Ne mel duis simul, quo ad euismod partiendo
+      p Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum.
+      p Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum. Ex debet appellantur eam, porro iuvaret in, per eu natum conceptam, nam at essent nam an case nemore mnesarchum. Sed porro iuvaret in, per eu natum conceptam, nam at essent petentium. Dicunt audiam aliquam eu sed, te mei decore maiorum.
       .meta
         time.meta-left datetime="2015-02-30"  30 Feb 2015
         em.meta-right News

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -665,7 +665,7 @@
 
       @include breakpoint(600px) {
         .block-container {
-          @include rem(height, 440px); // IE flexbox implementation bug
+          @include rem(height, 440px);
         }
 
         @supports (display: flex) {

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -1,16 +1,16 @@
 .uomcontent .block-listing {
   @include clearfix;
-  @include rem(margin-bottom, 30px);
-  @include rem(margin-top, 30px);
+  @include rem(margin-bottom, 32px);
+  @include rem(margin-top, 32px);
   background-color: transparent;
-  border: 0 none;
+  border: none;
   margin-left: auto;
   margin-right: auto;
   padding: 0 3%;
   width: 100%;
 
   li {
-    @include rem(margin-bottom, 15px);
+    @include rem(margin-bottom, 16px);
     background-color: transparent;
     border: 1px solid rgba($black, .15);
     box-shadow: 0 0 9px -3px rgba($black, .3);
@@ -26,7 +26,7 @@
 
   p {
     @include rem(font-size, 13px);
-    @include rem(padding, 15px 15px 0);
+    @include rem(padding, 16px 16px 0);
     background-color: transparent;
     color: inherit;
     line-height: 1.5;
@@ -34,13 +34,13 @@
     text-align: left;
 
     &:last-of-type {
-      @include rem(padding-bottom, 15px);
+      @include rem(padding-bottom, 16px);
     }
   }
 
   strong {
     @include rem(font-size, 20px);
-    @include rem(padding, 15px 15px 0);
+    @include rem(padding, 16px 16px 0);
     background-color: transparent;
     color: inherit;
     display: block;
@@ -58,7 +58,7 @@
   .meta {
     @include clearfix;
     @include rem(font-size, 12px);
-    @include rem(padding, 5px 15px);
+    @include rem(padding, 4px 16px);
     background-color: rgba($white, .9);
     color: inherit;
     width: 100%;
@@ -76,7 +76,8 @@
 
   .when {
     @include rem(font-size, 18px);
-    @include rem(padding, 10px 15px 0);
+    @include rem(margin-bottom, 14px);
+    @include rem(padding, 16px 16px 0);
     color: $salmon;
     font-weight: $regular;
     line-height: 1.4;
@@ -92,7 +93,7 @@
   }
 
   .range {
-    @include rem(margin-bottom, 13px);
+    @include rem(padding-top, 4px);
     line-height: 2.8;
     margin-bottom: 0;
 
@@ -101,7 +102,7 @@
       font-weight: $regular;
 
       &:first-child::after {
-        @include rem(width, 30px);
+        @include rem(width, 32px);
         border-bottom: 3px solid $highlight;
         content: '';
         display: block;
@@ -114,7 +115,7 @@
     color: $white;
 
     strong {
-      @include rem(margin-bottom, 30px);
+      @include rem(margin-bottom, 32px);
     }
 
     .meta {
@@ -151,7 +152,7 @@
     }
 
     .button-hero-inverse {
-      @include rem(margin-left, 25px);
+      @include rem(margin-left, 24px);
     }
   }
 
@@ -189,18 +190,18 @@
       width: 49%;
 
       strong {
-        @include rem(padding, 60px 30px 30px);
+        @include rem(padding, 64px 32px 32px);
         line-height: 1;
       }
 
       p {
-        @include rem(padding, 0 30px 15px);
+        @include rem(padding, 0 32px 16px);
         @include rem(font-size, 20px);
         line-height: 1.4;
       }
 
       .button-hero-inverse {
-        @include rem(margin-left, 30px);
+        @include rem(margin-left, 32px);
       }
     }
   }
@@ -210,26 +211,22 @@
       width: 24%;
     }
 
-    .when {
-      @include rem(margin-bottom, 30px);
-    }
-
     .double {
       width: 49%;
 
       strong {
         @include rem(font-size, 54px);
-        @include rem(padding, 60px 60px 30px);
+        @include rem(padding, 64px 64px 32px);
         line-height: 1.1;
       }
 
       p {
-        @include rem(padding, 0 60px 30px);
+        @include rem(padding, 0 64px 32px);
         line-height: 1.3;
       }
 
       .button-hero-inverse {
-        @include rem(margin-left, 60px);
+        @include rem(margin-left, 64px);
       }
     }
   }
@@ -315,8 +312,8 @@
 
     .news .meta::before {
       @include rem(height, 60px);
-      @include rem(margin-left, -15px);
-      @include rem(margin-right, -15px);
+      @include rem(margin-left, -16px);
+      @include rem(margin-right, -16px);
       @include rem(margin-top, -60px);
       background: linear-gradient(to top, rgba($white, .9) 33%, rgba($white, 0) 100%);
       content: ' ';
@@ -326,7 +323,7 @@
 
     .top-unit {
       @include rem(height, 410px);
-      @include rem(padding-top, 15px);
+      @include rem(padding-top, 16px);
       overflow: hidden;
       position: relative;
     }
@@ -413,13 +410,13 @@
         }
 
         @include breakpoint(tablet) {
-          @include rem(padding, 10px 25px);
+          @include rem(padding, 10px 24px);
           width: 100%;
         }
 
         @include breakpoint(wide) {
           @include adjust-font-size-to(26px);
-          @include rem(padding, 20px 25px);
+          @include rem(padding, 20px 24px);
         }
       }
 
@@ -427,8 +424,8 @@
         border-bottom-color: $highlight;
 
         strong {
-          @include rem(padding-bottom, 20px);
-          @include rem(padding-left, 30px);
+          @include rem(padding-bottom, 26px);
+          @include rem(padding-left, 26px);
           background-color: transparent;
 
           em {
@@ -436,7 +433,7 @@
           }
 
           span {
-            @include rem(padding-bottom, 5px);
+            @include rem(padding-bottom, 4px);
             background-color: $white;
             box-decoration-break: clone;
             box-shadow: 10px 0 0 $white, -10px 0 0 $white;
@@ -461,8 +458,8 @@
       background-size: cover;
 
       a {
-        @include rem(padding-left, 25px);
-        @include rem(padding-right, 25px);
+        @include rem(padding-left, 24px);
+        @include rem(padding-right, 24px);
       }
 
       span {
@@ -551,28 +548,23 @@
       border-right: 0;
       border-top: 0;
 
-      &:hover {
-        transform: none;
-      }
-
       a {
         background-color: transparent;
       }
 
       .meta {
-        @include rem(padding, 12px 20px);
+        @include rem(padding, 12px 20px 0);
         background-color: rgba($brand, 0.8);
         border: none;
         bottom: 0;
         color: $white;
         left: 0;
         margin: 0;
-        padding-bottom: 0;
         position: absolute;
         width: 100%;
 
         em {
-          @include rem(padding-bottom, 10px);
+          @include rem(padding-bottom, 8px);
           float: right;
         }
 
@@ -594,7 +586,7 @@
       }
 
       a {
-        @include rem(padding, 10px 0px);
+        @include rem(padding, 10px 0);
         border: 0;
         border-bottom: 1px solid $lightergray;
         color: $highlight;
@@ -607,6 +599,7 @@
 
         &:hover {
           background-color: $highlight;
+          border-bottom-color: transparent;
           color: $white;
         }
       }
@@ -614,7 +607,7 @@
       strong {
         @include adjust-font-size-to(13px);
         @include rem(letter-spacing, 1px);
-        @include rem(padding, 15px 0px);
+        @include rem(padding, 16px 0);
         color: currentColor;
         display: inline-block;
         font-weight: $bold;
@@ -626,7 +619,7 @@
         white-space: nowrap;
 
         span.small {
-          @include rem(margin-right, 5px);
+          @include rem(margin-right, 4px);
           margin-top: 0;
 
           @include breakpoint(0) {

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -160,8 +160,8 @@
     @include rem(max-width, $w-lge);
     li {
       margin-bottom: 1%;
-      margin-left: 0;
-      margin-right: 1%;
+      margin-left: .5%;
+      margin-right: .5%;
       margin-top: 0;
       width: 49%;
     }
@@ -182,8 +182,11 @@
       display: block;
     }
 
-    .event strong {
-      padding-top: 0;
+    .event,
+    .exhibition {
+      strong {
+        padding-top: 0;
+      }
     }
 
     .double {

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -67,6 +67,7 @@
     @include rem(padding, 4px 16px);
     background-color: rgba($white, .9);
     color: inherit;
+    position: relative;
     width: 100%;
 
     .meta-left {
@@ -82,7 +83,7 @@
 
   .when {
     @include rem(font-size, 18px);
-    @include rem(margin-bottom, 14px);
+    @include rem(margin-bottom, 16px);
     @include rem(padding, 16px 16px 0);
     color: $highlight;
     font-weight: $regular;
@@ -100,8 +101,8 @@
 
   .range {
     @include rem(padding-top, 4px);
+    @include rem(margin-bottom, 4px);
     line-height: 2.8;
-    margin-bottom: 0;
 
     time {
       @include rem(font-size, 18px);
@@ -116,23 +117,26 @@
     }
   }
 
-  .event {
+  .event,
+  .exhibition {
     background-color: $black;
     color: $white;
 
     strong {
-      @include rem(margin-bottom, 32px);
+      @include rem(margin-bottom, 24px);
+      padding-top: 0;
     }
 
     .meta {
-      border-top: 0 none;
+      border-top: none;
     }
   }
 
   .block-container {
     display: block;
+    overflow: hidden;
 
-    @include breakpoint(tablet) {
+    @include breakpoint(600px) {
       height: 440px;
       overflow: hidden;
     }
@@ -140,6 +144,7 @@
 
   .double {
     .block-container {
+      @include rem(padding, 32px 0 12px);
       background-color: rgba($black, .6);
       background-size: cover;
       color: $white;
@@ -158,7 +163,7 @@
     }
 
     .button-hero-inverse {
-      @include rem(margin-left, 24px);
+      @include rem(margin-left, 16px);
     }
   }
 
@@ -189,15 +194,12 @@
       display: block;
     }
 
-    .event,
-    .exhibition {
-      strong {
-        padding-top: 0;
-      }
-    }
-
     .double {
       width: 49%;
+
+      .block-container {
+        padding: 0;
+      }
 
       strong {
         @include rem(padding, 64px 32px 32px);
@@ -264,56 +266,48 @@
   }
 
   .crop-height {
+    @include rem(max-height, 190px);
     overflow: hidden;
 
     img {
       width: 100%;
     }
-
-    @include breakpoint(tablet) {
-      max-height: 190px;
-    }
-  }
-
-  li {
-    border-bottom: 4px solid $cta;
-  }
-
-  .event {
-    border-bottom-color: $highlight;
-  }
-
-  .exhibition {
-    border-bottom-color: $yellow;
   }
 
   .event,
   .exhibition {
-    .block-listing__img,
+    .crop-height,
+    .block-listing__img {
+      @include rem(margin-bottom, -28px);
+    }
+
     .crop-height {
-      @include breakpoint(tablet) {
-        bottom: 0;
-        left: 0;
-        position: absolute;
-        width: 100%;
-      }
+      @include rem(max-height, 240px);
     }
   }
 
-  @include breakpoint(tablet) {
+  li { border-bottom: 4px solid $cta; }
+  .event { border-bottom-color: $highlight; }
+  .exhibition { border-bottom-color: $yellow; }
+
+  @include breakpoint(600px) {
     .event,
     .exhibition {
+      .block-listing__img,
       .crop-height {
-        max-height: 240px;
-      }
-
-      .block-listing__img::before,
-      .crop-height::before {
-        @include rem(height, 50px);
-        background: linear-gradient(to top, rgba($white, 1) 10%, rgba($white, 0) 100%);
-        content: '';
-        display: block;
+        bottom: 0;
+        left: 0;
+        margin-bottom: 0;
+        position: absolute;
         width: 100%;
+
+        &::before {
+          @include rem(height, 50px);
+          background: linear-gradient(to top, rgba($white, 1) 10%, rgba($white, 0) 100%);
+          content: '';
+          display: block;
+          width: 100%;
+        }
       }
 
       .block-listing__img::before {
@@ -386,6 +380,7 @@
     }
 
     &.double {
+      background-position: center;
       background-repeat: no-repeat;
       background-size: cover;
 
@@ -422,7 +417,7 @@
           font-weight: $thin;
         }
 
-        @include breakpoint(tablet) {
+        @include breakpoint(600px) {
           @include rem(padding, 10px 24px);
           width: 100%;
         }
@@ -455,7 +450,7 @@
             line-height: 1.2;
           }
 
-          @include breakpoint(tablet) {
+          @include breakpoint(600px) {
             @include rem(font-size, 40px);
 
             span {

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -599,7 +599,6 @@
         border-bottom: 1px solid $lightergray;
         color: $highlight;
         display: block;
-        height: 100%;
         position: relative;
         text-align: center;
         vertical-align: middle;
@@ -667,16 +666,20 @@
       @include breakpoint(600px) {
         .block-container {
           @include rem(height, 440px); // IE flexbox implementation bug
-          align-items: flex-start;
-          display: flex;
-          flex-direction: column;
         }
 
-        a {
-          align-items: center;
-          display: flex;
-          flex: 1 0 0;
-          justify-content: center;
+        @supports (display: flex) {
+          .block-container {
+            display: flex;
+            flex-direction: column;
+          }
+
+          a {
+            align-items: center;
+            display: flex;
+            flex: 1;
+            justify-content: center;
+          }
         }
       }
     }

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -55,6 +55,12 @@
     text-decoration: none;
   }
 
+  img {
+    display: block;
+    height: auto;
+    -ms-interpolation-mode: bicubic;
+  }
+
   .meta {
     @include clearfix;
     @include rem(font-size, 12px);
@@ -78,7 +84,7 @@
     @include rem(font-size, 18px);
     @include rem(margin-bottom, 14px);
     @include rem(padding, 16px 16px 0);
-    color: $salmon;
+    color: $highlight;
     font-weight: $regular;
     line-height: 1.4;
     text-align: left;
@@ -158,6 +164,7 @@
 
   @include breakpoint(600px) {
     @include rem(max-width, $w-lge);
+
     li {
       margin-bottom: 1%;
       margin-left: .5%;
@@ -249,32 +256,22 @@
 }
 
 .uomcontent [role="main"] .block-listing {
+  .block-listing__img {
+    background-color: #fff;
+    background-position: center;
+    background-size: cover;
+    padding-top: 56.25%;
+  }
+
   .crop-height {
-    margin-top: 1em;
+    overflow: hidden;
 
     img {
-      display: block;
-      height: auto;
-      -ms-interpolation-mode: bicubic;
       width: 100%;
     }
 
-    @include breakpoint(wide) {
-      img {
-        max-height: 100%;
-        max-width: none;
-        width: auto;
-      }
-    }
-
     @include breakpoint(tablet) {
-      bottom: 0;
-      height: 210px;
-      overflow: hidden;
-      position: absolute;
-
-      img {
-      }
+      max-height: 190px;
     }
   }
 
@@ -283,34 +280,47 @@
   }
 
   .event {
-    background-color: $white;
-    border-bottom: 4px solid $highlight;
-    color: $black;
-
-    .when {
-      color: $highlight;
-    }
+    border-bottom-color: $highlight;
   }
 
   .exhibition {
-    background-color: $white;
-    border-bottom: 4px solid $yellow;
-    color: $black;
+    border-bottom-color: $yellow;
+  }
 
-    .when {
-      color: $highlight;
+  .event,
+  .exhibition {
+    .block-listing__img,
+    .crop-height {
+      @include breakpoint(tablet) {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        width: 100%;
+      }
     }
   }
 
   @include breakpoint(tablet) {
-    .crop-height::before {
-      @include rem(height, 50px);
-      @include rem(margin-top, -20px);
-      background: linear-gradient(to top, rgba($white, 1) 10%, rgba($white, 0) 100%);
-      content: ' ';
-      display: block;
-      position: relative;
-      width: 100%;
+    .event,
+    .exhibition {
+      .crop-height {
+        max-height: 240px;
+      }
+
+      .block-listing__img::before,
+      .crop-height::before {
+        @include rem(height, 50px);
+        background: linear-gradient(to top, rgba($white, 1) 10%, rgba($white, 0) 100%);
+        content: '';
+        display: block;
+        width: 100%;
+      }
+
+      .block-listing__img::before {
+        @include rem(top, -50px);
+        left: 0;
+        position: absolute;
+      }
     }
 
     .news .meta::before {
@@ -319,7 +329,7 @@
       @include rem(margin-right, -16px);
       @include rem(margin-top, -60px);
       background: linear-gradient(to top, rgba($white, .9) 33%, rgba($white, 0) 100%);
-      content: ' ';
+      content: '';
       display: block;
       width: auto;
     }
@@ -336,7 +346,7 @@
     }
 
     .mid-unit {
-      height: 90px;
+      @include rem(max-height, 90px);
     }
   }
 

--- a/assets/targets/components/listings/_block.scss
+++ b/assets/targets/components/listings/_block.scss
@@ -327,7 +327,7 @@
       @include rem(height, 60px);
       @include rem(margin-left, -16px);
       @include rem(margin-right, -16px);
-      @include rem(margin-top, -60px);
+      @include rem(margin-top, -64px); /* account for padding-top of 4px on `meta` */
       background: linear-gradient(to top, rgba($white, .9) 33%, rgba($white, 0) 100%);
       content: '';
       display: block;


### PR DESCRIPTION
- remove legacy `top-unit` containers from markup
- fix `crop-height` container
- implement new background-image option
- round rem values in output (e.g. 16px instead of 15)
- fix spacing of various elements, espcially in event/exhibition tiles
- fix centring of listing on page (0.5% margin on either side of every tile instead of 1% on the right)
- fix fading at bottom of news tiles
- document `crop-height` and `no-anim` and improve example markup