### PR TITLE
Fix responsive styles of notices and children of steps list

### DIFF
--- a/assets/targets/components/base/_typography.scss
+++ b/assets/targets/components/base/_typography.scss
@@ -328,8 +328,8 @@
 
       @include breakpoint(desktop) {
         & > li {
-          * {
-            max-width: 650px;
+          & > * {
+            max-width: 650px !important;
           }
 
           &::before {
@@ -352,8 +352,8 @@
         & > li {
           @include rem(padding-left, 110px);
 
-          > * {
-            margin-left: 0;
+          & > * {
+            margin-left: 0 !important;
           }
 
           li > * {
@@ -368,10 +368,8 @@
       }
 
       @include breakpoint(1400px) {
-        & > li {
-          * {
-            max-width: 700px;
-          }
+        & > li > * {
+          max-width: 700px !important;
         }
       }
     }

--- a/assets/targets/components/notices/_notices.scss
+++ b/assets/targets/components/notices/_notices.scss
@@ -1,17 +1,22 @@
 .uomcontent [role="main"] {
   .notice {
+    @include wrapper;
     @include rem(margin-bottom, 15px);
+    @include rem(max-width, $w-sml);
     @include rem(padding, 15px);
     display: block; /* allow inline elements (e.g. `span`) */
     margin-left: auto;
     margin-right: auto;
-    max-width: $w-sml;
 
     p,
     ul,
     ol,
     li {
       color: inherit;
+    }
+
+    @include breakpoint(tablet) {
+      @include rem(max-width, $w-sml);
     }
   }
 

--- a/assets/targets/components/notices/_notices.scss
+++ b/assets/targets/components/notices/_notices.scss
@@ -2,12 +2,10 @@
   .notice {
     @include rem(margin-bottom, 15px);
     @include rem(padding, 15px);
-    border: 1px solid rgba(0, 0, 0, 0.05);
-    border: 1px solid transparent;
+    display: block; /* allow inline elements (e.g. `span`) */
     margin-left: auto;
     margin-right: auto;
     max-width: $w-sml;
-    width: 100%;
 
     p,
     ul,


### PR DESCRIPTION
- use `wrapper` mixin for notices to get the same behaviour as paragraphs on mobile (94% width)
- force `margin-left: 0;` and `max-width` on direct children of steps list to bypass selector specificity issues