### PR TITLE
Relax version tracking regex

### DIFF
--- a/assets/targets/injection/tealium/index.js
+++ b/assets/targets/injection/tealium/index.js
@@ -2,9 +2,9 @@
   window.utag_data = window.utag_data || {};
 
   // Track design system version
-  var uomScript = document.querySelector('script[src$="uom.js"]');
+  var uomScript = document.querySelector('script[src*="uom.js"]');
   if (uomScript) {
-    var uomVersion = /\/v([0-9]+\.[0-9]+(?:\.[0-9]+)?)\/uom\.js$/.exec(uomScript.src);
+    var uomVersion = /\/v([0-9]+\.[0-9]+(?:\.[0-9]+)?)\/uom\.js/.exec(uomScript.src);
     window.utag_data.uom_version = uomVersion.length >= 2 ? uomVersion[1] : 'cannot-parse-version';
   } else {
     window.utag_data.uom_version = 'script-not-found';


### PR DESCRIPTION
Some WordPress sites append a query string at the end of the `uom.js` script URL.