### PR TITLE
Compute gallery image ratios from `data-size` attributes

### DIFF
--- a/assets/targets/components/gallery/01-gallery.slim
+++ b/assets/targets/components/gallery/01-gallery.slim
@@ -1,3 +1,11 @@
+p The gallery component is useful to display a set of large photos. For each photo, you must provide the following information:
+ul
+  li the URL of the full-size version (in the <code>href</code> attribute of the anchor element),
+  li the dimensions of the full-size version (in the <code>data-size</code> attribute of the anchor element),
+  li the URL of the thumbnail version (in the <code>src</code> attribute of the image element),
+  li a caption and/or text alternative (<code>figcaption</code> element or <code>alt</code> attribute).
+p.notice.notice--info <strong>Note:</strong> Captions and text alternatives have different purposes, make sure you <a href="http://4syllables.com.au/articles/text-alternatives-images-captions/">use them the right way</a>.
+
 ul.image-gallery
   li.item
     a href="/assets/gallery/1.jpg" data-size="1500x1000"

--- a/assets/targets/components/gallery/index.js
+++ b/assets/targets/components/gallery/index.js
@@ -42,17 +42,21 @@ ImageGallery.prototype.setupGallery = function () {
     icon.innerHTML = '<svg role="img" class="icon"><use xlink:href="#icon-zoom-in"></use></svg>';
     link.appendChild(icon);
 
-    // Compute thumbnail ratio and add corresponding class
-    var ratio = img.offsetWidth / img.offsetHeight;
+    // Retrieve image dimensions from `data-size` attribute
+    var size = link.getAttribute('data-size').split('x');
+    var w = parseInt(size[0], 10);
+    var h = parseInt(size[1], 10);
+
+    // Compute image ratio and add corresponding class
+    var ratio = w / h;
     item.classList.add(ratio < 1 ? 'portrait' : (ratio > 2 ? 'panorama' : 'landscape'));
 
     // Create PhotoSwipe slide
-    var size = link.getAttribute('data-size').split('x');
     this.props.slides.push({
       el: link,
       src: link.getAttribute('href'),
-      w: parseInt(size[0], 10),
-      h: parseInt(size[1], 10),
+      w: w,
+      h: h,
       title: item.querySelector('figcaption').innerHTML,
       msrc: img.src
     });


### PR DESCRIPTION
... rather than from thumbnails dimensions, as thumbnails may not have fully loaded when gallery code runs.