### PR TITLE
Fix tab panels initialisation order

### DIFF
--- a/assets/targets/components/tabs/index.js
+++ b/assets/targets/components/tabs/index.js
@@ -45,11 +45,11 @@ function Tabs(el, props) {
  * Set up the tab panels and event listeners.
  */
 Tabs.prototype.setup = function() {
-  var i, tab;
+  var i, len, tab;
 
   // Hide all panels by default
   var panels = this.el.querySelectorAll('[role="tabpanel"]');
-  for (i = panels.length - 1; i >= 0; i--) {
+  for (i = 0, len = panels.length; i < len; i++) {
     if (panels[i].parentElement === this.el) { // exclude panels of any nested tabs component
       panels[i].style.display = 'none';
       this.props.panels.push(panels[i]);


### PR DESCRIPTION
Fix #842

The tab panels were being initialised in the wrong order, so when attempting to switch to a tab at a specific index, the wrong panel was being shown (e.g. when trying to switch to tab no. 1 in a 3-tab component, it would switch to tab no. 3).