### PR TITLE
Update links in footer and enquiry component

### DIFF
--- a/assets/components/enquiry/01-enquiry.slim
+++ b/assets/components/enquiry/01-enquiry.slim
@@ -33,9 +33,9 @@
             hr.spacer
             p.form__subtext
               ' The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the
-              a> href="http://www.unimelb.edu.au/unisec/privacy/contact.html" Privacy Officer
+              a> href="http://www.unimelb.edu.au/governance/compliance/privacy/contacts" Privacy Officer
               ' to find out more. The
-              a> href="http://www.unimelb.edu.au/disclaimer/privacy.html" University’s Privacy Policy
+              a> href="http://www.unimelb.edu.au/governance/compliance/privacy" University’s Privacy Policy
               | is available online.
   .enquiry__subline
     .first

--- a/assets/components/enquiry/02-enquiry-dark.slim
+++ b/assets/components/enquiry/02-enquiry-dark.slim
@@ -29,9 +29,9 @@
             hr.spacer
             p.form__subtext
               ' The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the
-              a> href="http://www.unimelb.edu.au/unisec/privacy/contact.html" Privacy Officer
+              a> href="http://www.unimelb.edu.au/governance/compliance/privacy/contacts" Privacy Officer
               ' to find out more. The
-              a> href="http://www.unimelb.edu.au/disclaimer/privacy.html" University’s Privacy Policy
+              a> href="http://www.unimelb.edu.au/governance/compliance/privacy" University’s Privacy Policy
               | is available online.
   .enquiry__subline
     .first

--- a/assets/components/footer/index.es6
+++ b/assets/components/footer/index.es6
@@ -56,16 +56,16 @@ InjectFooter.prototype.renderFooter = function() {
   <div class="ind-ack">We acknowledge and pay respect to the Traditional Owners of the lands upon which our campuses are situated.</div>
   <ul class="page-footer-section nav">
     <li>
-      <a href="http://safety.unimelb.edu.au/about/contacts/emergency.html">Emergency Information</a>
+      <a href="http://safety.unimelb.edu.au/emergency">Emergency Information</a>
     </li>
     <li>
-      <a href="http://www.unimelb.edu.au/disclaimer/">Disclaimer &amp; Copyright</a>
+      <a href="http://www.unimelb.edu.au/governance/disclaimer">Disclaimer &amp; Copyright</a>
     </li>
     <li>
-      <a href="http://www.unimelb.edu.au/accessibility/index.html">Accessibility</a>
+      <a href="http://www.unimelb.edu.au/accessibility">Accessibility</a>
     </li>
     <li>
-      <a href="http://www.unimelb.edu.au/disclaimer/privacy.html">Privacy</a>
+      <a href="http://www.unimelb.edu.au/governance/compliance/privacy">Privacy</a>
     </li>
   </ul>
   <ul class="page-footer-section social">

--- a/views/pages/audio-video-guidelines.slim.md
+++ b/views/pages/audio-video-guidelines.slim.md
@@ -14,11 +14,11 @@ p The university has procured a 3rd party service who can assist with creating t
 
 h2 Video
 
-p Video should include captions that conform to <a href="http://www.unimelb.edu.au/accessibility/captioning/style-guide.htm">the university captioning style guide</a>.
+p Video should include captions that conform to <a href="http://www.unimelb.edu.au/accessibility/video-captioning/style-guide">the university captioning style guide</a>.
 
 p The university has procured a 3rd party service who can assist with captioning video. Contact the digital team for details on this service.
 
-p Video used needs to comply with <a href="http://marketing.unimelb.edu.au/imagebank/guidelines.html">the university video guidelines</a>.
+p Video used needs to comply with <a href="https://staff.unimelb.edu.au/marketing-communications/resources/photos-video-guidelines">the university video guidelines</a>.
 
 hr
 section

--- a/views/templates/fake-tab.slim
+++ b/views/templates/fake-tab.slim
@@ -114,9 +114,9 @@ div role="main"
                   hr.spacer
                   p.form__subtext
                     ' The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the
-                    a> href="http://www.unimelb.edu.au/unisec/privacy/contact.html" Privacy Officer
+                    a> href="http://www.unimelb.edu.au/governance/compliance/privacy/contacts" Privacy Officer
                     ' to find out more. The
-                    a> href="http://www.unimelb.edu.au/disclaimer/privacy.html" University’s Privacy Policy
+                    a> href="http://www.unimelb.edu.au/governance/compliance/privacy" University’s Privacy Policy
                     | is available online.
         .enquiry__subline
           .first

--- a/views/templates/intranet.slim
+++ b/views/templates/intranet.slim
@@ -201,9 +201,9 @@ div role="main"
               hr.spacer
               p.form__subtext
                 ' The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the
-                a> href="http://www.unimelb.edu.au/unisec/privacy/contact.html" Privacy Officer
+                a> href="http://www.unimelb.edu.au/governance/compliance/privacy/contacts" Privacy Officer
                 ' to find out more. The
-                a> href="http://www.unimelb.edu.au/disclaimer/privacy.html" University’s Privacy Policy
+                a> href="http://www.unimelb.edu.au/governance/compliance/privacy" University’s Privacy Policy
                 | is available online.
     .enquiry__subline
       .first


### PR DESCRIPTION
Fix #851 


### Breaking change

The links in the terms and conditions of the enquiry component have been updated. One of the links was broken and the other was pointing to the _Disclaimer_ rather than _Privacy_ page.