### PR TITLE
Cosmetic tweaks

### DIFF
--- a/assets/components/accordion/index.js
+++ b/assets/components/accordion/index.js
@@ -6,7 +6,7 @@
  */
 function Accordion(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.props.container = this.el.parentNode;
   this.props.hidden = this.props.container.querySelector('.accordion__hidden');

--- a/assets/components/checklist/checkboxhelper.js
+++ b/assets/components/checklist/checkboxhelper.js
@@ -8,7 +8,7 @@ function CheckboxHelper(el, props) {
   "use strict";
 
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.props.parent = this.el.parentNode;
   this.props.parent.addEventListener('click', this.handleClick.bind(this));
 }

--- a/assets/components/checklist/checkboxhelper.js
+++ b/assets/components/checklist/checkboxhelper.js
@@ -5,8 +5,6 @@
  * @param  {Object} props
  */
 function CheckboxHelper(el, props) {
-  "use strict";
-
   this.el = el;
   this.props = props || {};
   this.props.parent = this.el.parentNode;

--- a/assets/components/checklist/index.js
+++ b/assets/components/checklist/index.js
@@ -5,8 +5,6 @@
  * @param  {Object} props
  */
 function Checklist(el, props) {
-  "use strict";
-
   this.el = el;
   this.props = props || {};
 

--- a/assets/components/checklist/index.js
+++ b/assets/components/checklist/index.js
@@ -8,7 +8,7 @@ function Checklist(el, props) {
   "use strict";
 
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.props.target = document.getElementById(this.el.getAttribute('data-unlock-target'));
   this.props.target.addEventListener('click', this.handleTargetClick.bind(this));

--- a/assets/components/forms/fancyselect.js
+++ b/assets/components/forms/fancyselect.js
@@ -10,7 +10,7 @@ function FancySelect(el, props) {
   "use strict";
 
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.props.parent = this.el.parentNode;
 
   // Only fancify if it hasn't already been done

--- a/assets/components/forms/fancyselect.js
+++ b/assets/components/forms/fancyselect.js
@@ -7,8 +7,6 @@
  * @param  {Object} props
  */
 function FancySelect(el, props) {
-  "use strict";
-
   this.el = el;
   this.props = props || {};
   this.props.parent = this.el.parentNode;

--- a/assets/components/forms/index.js
+++ b/assets/components/forms/index.js
@@ -7,8 +7,6 @@ var utils = require('../../utils');
  * @param  {Object} props
  */
 function ValidateForm(el, props) {
-  "use strict";
-
   this.el = el;
   this.props = props || {};
 

--- a/assets/components/forms/index.js
+++ b/assets/components/forms/index.js
@@ -10,7 +10,7 @@ function ValidateForm(el, props) {
   "use strict";
 
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.props.patterns = {
     alpha         : /[a-zA-Z]+/,

--- a/assets/components/icons/index.js
+++ b/assets/components/icons/index.js
@@ -5,7 +5,7 @@
  */
 function IconHelper(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   // Allow providing icon target with or without the `#icon-` prefix
   this.props.ref = this.el.getAttribute('data-icon');

--- a/assets/components/inpage-navigation/index.js
+++ b/assets/components/inpage-navigation/index.js
@@ -8,7 +8,7 @@ var utils = require('../../utils');
  */
 function InPageNavigation(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.el.addEventListener('click', this.delegateScroll.bind(this));
 }
 

--- a/assets/components/inpage-navigation/jumpnav.js
+++ b/assets/components/inpage-navigation/jumpnav.js
@@ -5,7 +5,7 @@ var componentManager = require('shared/component-manager');
  * @param  {Object} props
  */
 function JumpNav(el, props) {
-  this.props = props;
+  this.props = props || {};
   this.props.root = document.querySelector('[role="main"]');
   this.props.headings = this.props.root.querySelectorAll('h2[id]');
   this.props.topmode = el.classList.contains('top');

--- a/assets/components/maps/lmaps.js
+++ b/assets/components/maps/lmaps.js
@@ -5,7 +5,7 @@
  */
 function LMaps(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.props.latlng = this.el.getAttribute('data-leaflet-latlng').split(',');
   this.props.zoom = parseInt(this.el.getAttribute('data-zoom')) || 15;

--- a/assets/components/modal/index.js
+++ b/assets/components/modal/index.js
@@ -7,7 +7,7 @@ var Blanket = require('shared/blanket');
  */
 function Modal(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.props.target = document.getElementById(el.getAttribute('data-modal-target'));
 
   // Bind only if modal has target

--- a/assets/components/notices/flash.js
+++ b/assets/components/notices/flash.js
@@ -5,7 +5,7 @@
  */
 function Flash(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   var main = document.querySelector('[role="main"]');
   var headerless = document.querySelector('.headerless');

--- a/assets/components/tables/index.js
+++ b/assets/components/tables/index.js
@@ -6,7 +6,7 @@
  */
 function MobileTableHelper(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
 
   this.props.labels = this.el.querySelectorAll('thead th');
 

--- a/assets/components/tables/sortable.js
+++ b/assets/components/tables/sortable.js
@@ -6,7 +6,7 @@
  */
 function SortableTable(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.props.tbody = this.el.querySelector('tbody');
 
   this.setupData();

--- a/assets/components/tabs/index.js
+++ b/assets/components/tabs/index.js
@@ -16,7 +16,7 @@ var DEBOUNCE_DELAY = 100;
  */
 function Tabs(el, props) {
   this.el = el;
-  this.props = props;
+  this.props = props || {};
   this.props.nav = this.el.querySelector('nav');
   this.props.navParent = this.props.nav.parentElement;
   this.props.tabs = this.el.querySelectorAll('nav a');

--- a/assets/shared/component-manager.es6
+++ b/assets/shared/component-manager.es6
@@ -104,7 +104,7 @@ function initMatches(Component, matches) {
   matches.forEach(el => {
     // Retrieve and parse props (only allow JSON object)
     const rawProps = el.getAttribute('data-props');
-    const props = /^{/.test(rawProps) ? JSON.parse(rawProps) : {};
+    const props = rawProps && /^{/.test(rawProps) ? JSON.parse(rawProps) : {};
 
     // Create new instance
     new Component(el, props);

--- a/assets/shared/create-namespace.js
+++ b/assets/shared/create-namespace.js
@@ -4,8 +4,6 @@
  * @param  {Object} props
  */
 function CreateNameSpace() {
-  "use strict";
-
   var bodyclass;
   if (/(MSIE 9.0)/g.test(navigator.userAgent))
     bodyclass = 'ie ie9';


### PR DESCRIPTION
- remove all occurrences of "use strict" made obsolete by webpack
- always initialise `props` object in component constructors in case one is not passed