### PR TITLE
Sub-links in search results

### DIFF
--- a/assets/components/search/02-search-results.slim
+++ b/assets/components/search/02-search-results.slim
@@ -8,19 +8,6 @@ h2.search-title All results
 ol.search-results
   li
     h3: a href="" Accelerated Mathematics
-    dl.search-results__meta
-      dt> Year:
-      dd 2017
-      dt> Type:
-      dd Breadth track
-    p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
-    p.url: a href="" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
-    ul.search-results__subs
-      li: a.search-results__sub-link href="" Course structure
-      li: a.search-results__sub-link href="" Subject options
-      li: a.search-results__sub-link href="" Breadth requirements
-  li
-    h3: a href="" Bachelor of Science Extended — Course Search · The Universit...
     p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
     p.url: a href="" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
   li
@@ -41,10 +28,6 @@ ol.search-results
     p.url: a href="" maps.unimelb.edu.au/parkville
     p.more
       a href="" More results from maps.unimelb.edu.au
-  li
-    h3: a href="" History and Philosophy of Science
-    p History and Philosophy of Science (HPS) is a unique discipline in the Faculty of Arts, which brings together perspectives from the history of science and medicine  ...
-    p.url: a href="" shaps.unimelb.edu.au/history-philosophy-science
   li.person
     .person__photo style="background-image: url(https://findanexpert.unimelb.edu.au/pictures/thumbnail195234picture);"
     .person__info
@@ -56,6 +39,19 @@ ol.search-results
         p.person__phone: a href="tel:+61383440346" +61 3 8344 0346
         p.person__email: a href="mailto:chaz-batrouney@unimelb.edu.au" chaz-batrouney@unimelb.edu.au
   li
-    h3: a href="" Master of Food Science — Faculty of Veterinary and Agriculture ...
-    p Investigate the interdisciplinary nature of agriculture, food production and food science at an advanced level; Strengthen your food chemistry, microbiology, ...
-    p.url: a href="" fvas.unimelb.edu.au/study/courses/master-of-food-science
+    h3: a href="" History and Philosophy of Science
+    dl.search-results__meta
+      dt> Year:
+      dd 2017
+      dt> Type:
+      dd Breadth track
+    p History and Philosophy of Science (HPS) is a unique discipline in the Faculty of Arts, which brings together perspectives from the history of science and medicine  ...
+    p.url: a href="" shaps.unimelb.edu.au/history-philosophy-science
+  li
+    h3: a href="" Bachelor of Science Extended
+    p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
+    p.url: a href="" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
+    ul.search-results__subs
+      li: a.search-results__sub-link href="" Course structure
+      li: a.search-results__sub-link href="" Subject options
+      li: a.search-results__sub-link href="" Breadth requirements

--- a/assets/components/search/02-search-results.slim
+++ b/assets/components/search/02-search-results.slim
@@ -1,74 +1,61 @@
 h2.search-title Recommended
 ol.search-results.search-results--promoted
   li
-    h3
-      a href="http://science.unimelb.edu.au/" Faculty of Science
+    h3: a href="http://science.unimelb.edu.au/" Faculty of Science
     p We offer a range of undergraduate, graduate and research higher degree courses that prepare students for a successful career.
-    p.url
-      a href="http://science.unimelb.edu.au/" science.unimelb.edu.au/
+    p.url: a href="http://science.unimelb.edu.au/" science.unimelb.edu.au/
 h2.search-title All results
 ol.search-results
   li
-    h3
-      a href="" Accelerated Mathematics
+    h3: a href="" Accelerated Mathematics
     dl.search-results__meta
       dt> Year:
       dd 2017
       dt> Type:
       dd Breadth track
     p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
-    p.url
-      a href="http://science.unimelb.edu.au/" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
+    p.url: a href="" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
+    ul.search-results__subs
+      li: a.search-results__sub-link href="" Course structure
+      li: a.search-results__sub-link href="" Subject options
+      li: a.search-results__sub-link href="" Breadth requirements
   li
-    h3
-      a href="" Bachelor of Science Extended — Course Search · The Universit...
+    h3: a href="" Bachelor of Science Extended — Course Search · The Universit...
     p The Bachelor of Science (Extended) is a four-year degree that provides a pathway for Indigenous students to embark on careers that build on a strong science ...
-    p.url
-      a href="http://science.unimelb.edu.au/" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
+    p.url: a href="" coursesearch.unimelb.edu.au/.../1948-bachelor-of-science-extended
   li
-    h3
-      a href="" Breadth Requirements for the Bachelor of Science : Breadth...
+    h3: a href="" Breadth Requirements for the Bachelor of Science : Breadth...
     p
       span.icon--hide-label> data-icon="lock" Secure result
       | Bachelor of Science students complete a breadth component of 50 points (four subjects), with another 25 points (two subjects) of free (that is, breadth or core) ...
-    p.url
-      a href="http://science.unimelb.edu.au/" breadth.unimelb.edu.au/breadth/info/Science.html
+    p.url: a href="" breadth.unimelb.edu.au/breadth/info/Science.html
   li
     img src="/assets/example/tsinghua_university.jpg" alt="Tsinghua University"
-    h3
-      a href="" School of Social and Political Sciences | Political Science
+    h3: a href="" School of Social and Political Sciences | Political Science
     p Political science explores the main issues, ideas, institutions and actors that dominate local, national and international politics. It focuses on how people engage ...
-    p.url
-      a href="http://science.unimelb.edu.au/" ssps.unimelb.edu.au/study-areas/political-science
+    p.url: a href="" ssps.unimelb.edu.au/study-areas/political-science
   li
     img src="http://open.mapquestapi.com/staticmap/v4/getmap?size=130,130&zoom=14&center=-37.79894,144.96073&scalebar=false&pois=blue,-37.79894,144.96073&key=Fmjtd%7Cluur2l6r2u%2C7a%3Do5-90ywlw" alt="Map of Parville campus"
-    h3
-      a href="" Parkville Campus : Maps
+    h3: a href="" Parkville Campus : Maps
     p Maps. Maps Parkville. Parkville Campus. ... Gates. Burnley; Creswick; Dookie; Shepparton; Southbank; Werribee. Maps. More maps and information are available. ...
-    p.url
-      a href="http://science.unimelb.edu.au/" maps.unimelb.edu.au/parkville
+    p.url: a href="" maps.unimelb.edu.au/parkville
     p.more
       a href="" More results from maps.unimelb.edu.au
   li
-    h3
-      a href="" History and Philosophy of Science
+    h3: a href="" History and Philosophy of Science
     p History and Philosophy of Science (HPS) is a unique discipline in the Faculty of Arts, which brings together perspectives from the history of science and medicine  ...
-    p.url
-      a href="http://science.unimelb.edu.au/" shaps.unimelb.edu.au/history-philosophy-science
+    p.url: a href="" shaps.unimelb.edu.au/history-philosophy-science
   li.person
     .person__photo style="background-image: url(https://findanexpert.unimelb.edu.au/pictures/thumbnail195234picture);"
     .person__info
       .person__profile
-        h3
-          a href="" Chaz Batrouney
+        h3: a href="" Chaz Batrouney
         p: em Web Producer
         p Project Services
       .person__contact
         p.person__phone: a href="tel:+61383440346" +61 3 8344 0346
         p.person__email: a href="mailto:chaz-batrouney@unimelb.edu.au" chaz-batrouney@unimelb.edu.au
   li
-    h3
-      a href="" Master of Food Science — Faculty of Veterinary and Agriculture ...
+    h3: a href="" Master of Food Science — Faculty of Veterinary and Agriculture ...
     p Investigate the interdisciplinary nature of agriculture, food production and food science at an advanced level; Strengthen your food chemistry, microbiology, ...
-    p.url
-      a href="http://science.unimelb.edu.au/" fvas.unimelb.edu.au/study/courses/master-of-food-science
+    p.url: a href="" fvas.unimelb.edu.au/study/courses/master-of-food-science

--- a/assets/components/search/_search-results.css
+++ b/assets/components/search/_search-results.css
@@ -103,6 +103,10 @@
 
     a {
       text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
 
     img,

--- a/assets/components/search/_search-results.css
+++ b/assets/components/search/_search-results.css
@@ -206,15 +206,26 @@
     line-height: 1.4;
 
     & > li {
+      margin-bottom: .25rem;
       padding: 0;
       list-style-type: inherit;
       color: inherit;
     }
 
     @supports (display: grid) {
-      display: grid;
-      grid-gap: .25rem 1rem;
-      grid-template-columns: repeat(2, minmax(15rem, max-content));
+      @media (--bp-tablet) {
+        display: grid;
+        grid-gap: .25rem 1rem;
+        grid-template-columns: repeat(2, 1fr);
+
+        & > li {
+          margin-bottom: 0;
+        }
+      }
+
+      @media (--bp-x-tablet) {
+        grid-template-columns: repeat(2, minmax(15rem, max-content));
+      }
     }
   }
 }

--- a/assets/components/search/_search-results.css
+++ b/assets/components/search/_search-results.css
@@ -193,4 +193,24 @@
       margin-left: 1rem;
     }
   }
+
+  /* Sub-links */
+  .search-results__subs {
+    margin-top: .75rem;
+    padding: 0;
+    list-style-type: circle;
+    line-height: 1.4;
+
+    & > li {
+      padding: 0;
+      list-style-type: inherit;
+      color: inherit;
+    }
+
+    @supports (display: grid) {
+      display: grid;
+      grid-gap: .25rem 1rem;
+      grid-template-columns: repeat(2, minmax(15rem, max-content));
+    }
+  }
 }

--- a/assets/shared/component-manager.es6
+++ b/assets/shared/component-manager.es6
@@ -97,7 +97,7 @@ function findMatches(context, rawSelector, firstOnly) {
   }
 
   // Look for all matches
-  return Array.from(context.querySelectorAll(selector))
+  return [].slice.call(context.querySelectorAll(selector));
 }
 
 /**


### PR DESCRIPTION
Fix #840 - Display a list of sub-links underneath a search result.

<img width="795" alt="screen shot 2017-05-15 at 3 16 24 pm" src="https://cloud.githubusercontent.com/assets/2936402/26044165/006c1530-3986-11e7-9649-4f9a74d9b80a.png">