### PR TITLE
Review spacing of lists and list items

### DIFF
--- a/assets/components/accordion/_accordion.css
+++ b/assets/components/accordion/_accordion.css
@@ -37,7 +37,6 @@
   }
 
   ul.accordion {
-    @mixin inner-list-reset;
     padding-left: 0;
     padding-right: 0;
 
@@ -45,6 +44,7 @@
       border-bottom: 1px solid color(var(--col-lightgray) lightness(-5%));
       list-style-type: none;
       margin: 0;
+      padding-bottom: 0;
       max-width: 2000px;
       width: 100%;
 
@@ -130,6 +130,9 @@
         padding-left: .9375rem;
         padding-right: .9375rem;
         display: none;
+
+        /* reset inner lists */
+        @mixin inner-list-reset;
       }
 
       &.accordion__visible {

--- a/assets/components/accordion/_accordion.css
+++ b/assets/components/accordion/_accordion.css
@@ -37,6 +37,7 @@
   }
 
   ul.accordion {
+    @mixin inner-list-reset;
     padding-left: 0;
     padding-right: 0;
 
@@ -47,24 +48,7 @@
       max-width: 2000px;
       width: 100%;
 
-      @mixin inner-list-reset;
-
-      padding: 0;
-
-      /* Ridiculous overrides */
-      ol,
-      ul {
-        padding-bottom: 1.875rem;
-
-        ol,
-        ul {
-          padding-bottom: 0;
-        }
-      }
-
       ol.steps {
-        @mixin inner-list-reset;
-
         ol,
         ul {
           padding-left: 2.1875rem;

--- a/assets/components/base/03-05-ordered-list-steps.slim
+++ b/assets/components/base/03-05-ordered-list-steps.slim
@@ -7,24 +7,24 @@ ol class="steps"
     p Cum ceteris in veneratione <strong>tui montes</strong>, nascetur mus. Petierunt uti sibi concilium totius Galliae in diem certam indicere. Quisque ut dolor gravida, placerat libero vel, euismod. Fabio vel iudice vincam, sunt in culpa qui officia. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae. Sed haec quis possit intrepidus aestimare tellus.
   li
     h2 Headline
-    p Quisque ut dolor gravida, placerat libero vel, euismod. Fabio vel iudice vincam, sunt in culpa qui officia. Cum ceteris in veneratione tui montes, nascetur mus. Petierunt uti sibi concilium totius Galliae in diem certam indicere.
-  li
-    h2 Headline
-    p Fabio vel iudice vincam, sunt in culpa qui officia. Petierunt uti sibi concilium totius Galliae in diem certam indicere. Quisque ut dolor gravida, placerat libero vel, euismod. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae. Sed haec quis possit intrepidus aestimare tellus.
-
-  li
-    h2 Headline
     p Petierunt uti sibi concilium totius Galliae in diem certam indicere. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae. Sed haec quis possit intrepidus aestimare tellus.
     ul
-      li Item
+      li
+        | Item
+        ol
+          li This is a nested list
+          li with two items.
       li Item
     ul.ticked-list
       li Item
       li Item
     ol
+      li
+        | Item
+        ol
+          li This is a nested list
+          li with two items.
       li Item
-      li Item
-
   li
     h2 Headline
     p Petierunt uti sibi concilium totius Galliae in diem certam indicere. Quisque ut dolor gravida, placerat libero vel, euismod. Fabio vel iudice vincam, sunt in culpa qui officia. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae. Sed haec quis possit intrepidus aestimare tellus. Cum ceteris in veneratione tui montes, nascetur mus.

--- a/assets/components/base/_typography.css
+++ b/assets/components/base/_typography.css
@@ -3,94 +3,6 @@
   to { filter: hue-rotate(-360deg); }
 }
 
-@define-mixin inner-list-reset {
-  padding-bottom: 1.875rem;
-
-  ul li {
-    list-style-type: disc;
-
-    ol,
-    ul {
-      padding-top: .5em;
-    }
-  }
-
-  ol li {
-    list-style-type: decimal;
-
-    ol,
-    ul {
-      padding-bottom: 0;
-      padding-top: .5em;
-    }
-
-    ol li {
-      list-style-type: lower-alpha;
-
-      ol li {
-        list-style-type: lower-roman;
-      }
-    }
-
-    ul li {
-      list-style-type: disc;
-    }
-  }
-
-  .ticked-list li,
-  .no-li,
-  ol.steps li {
-    list-style-type: none;
-  }
-}
-
-@define-mixin ticks {
-  padding-left: 1.875rem;
-
-  @media screen and (--bp-desktop) {
-    padding-left: 1.25rem;
-  }
-
-  li {
-    list-style-type: none;
-    position: relative;
-
-    &::before {
-      height: .3125rem;
-      left: .375rem;
-      margin-left: -1.875rem;
-      top: .375rem;
-      width: .625rem;
-      background: transparent;
-      border: 3px solid var(--col-green);
-      border-right: 0 none;
-      border-top: 0 none;
-      content: '';
-      position: absolute;
-      transform: rotate(-45deg);
-    }
-
-    &.disabled::before {
-      opacity: .2;
-    }
-
-
-    ul {
-      padding-top: .75rem;
-      padding-bottom: 0;
-    }
-
-    li {
-      list-style-type: disc;
-
-      &::before {
-        display: none;
-      }
-    }
-  }
-}
-
-
 .uomcontent {
 	background-color: #fff;
   font-family: var(--ff-sans);
@@ -186,18 +98,23 @@
   ol,
   ul {
     max-width: var(--w-sml);
+    margin: 0 auto;
     padding-left: .9375rem;
     padding-right: .9375rem;
+    padding-bottom: 1.5rem;
     color: var(--col-darkgray);
     list-style-position: outside;
-    margin: 0 auto;
 
     li {
-      padding-bottom: .75rem;
+      padding-bottom: .5rem;
       margin-left: .9375rem;
       max-width: var(--w-sml);
       color: #000;
       display: list-item;
+
+      &:last-child {
+        padding-bottom: 0;
+      }
 
       &.no-li {
         list-style-type: none;
@@ -205,10 +122,6 @@
         &::before {
           display: none;
         }
-      }
-
-      &:last-child {
-        padding-bottom: 0;
       }
     }
 
@@ -223,12 +136,30 @@
       }
     }
 
-    @mixin inner-list-reset;
-
-    /* Remove bottom padding for inner lists */
     ol,
     ul {
+      padding-top: .5rem;
       padding-bottom: 0;
+    }
+
+    ul li {
+      list-style-type: disc;
+    }
+
+    ol li {
+      list-style-type: decimal;
+
+      ol li {
+        list-style-type: lower-alpha;
+
+        ol li {
+          list-style-type: lower-roman;
+        }
+      }
+
+      ul li {
+        list-style-type: disc;
+      }
     }
   }
 
@@ -328,7 +259,14 @@
       ul {
         padding-left: 1.25rem;
         padding-right: 1.25rem;
-        padding-top: .5em;
+      }
+
+      & > li {
+        & > ol,
+        & > ul {
+          padding-top: 0;
+          padding-bottom: 1rem;
+        }
       }
 
       @media screen and (--bp-desktop) {
@@ -410,7 +348,6 @@
     ol {
       counter-reset: section;
       list-style-type: none;
-      padding: 1em 0 0;
 
       li::before {
         content: counters(section,".") " ";
@@ -419,15 +356,10 @@
       &[type="a"],
       &[type="i"] {
         padding-left: 2.625rem;
-        padding-top: .75rem;
 
         li::before {
           display: none;
         }
-      }
-
-      li:last-child {
-        padding-bottom: 0;
       }
 
       &[type="a"] li {
@@ -483,12 +415,36 @@
   	}
 
     &.ticked-list {
-      @mixin ticks;
-    }
-  }
+      padding-left: 1.875rem;
 
-  .ticked-list ul {
-    @mixin ticks;
+      @media screen and (--bp-desktop) {
+        padding-left: 1.25rem;
+      }
+
+      & > li {
+        list-style-type: none;
+        position: relative;
+
+        &::before {
+          height: .3125rem;
+          left: .375rem;
+          margin-left: -1.875rem;
+          top: .375rem;
+          width: .625rem;
+          background: transparent;
+          border: 3px solid var(--col-green);
+          border-right: 0 none;
+          border-top: 0 none;
+          content: '';
+          position: absolute;
+          transform: rotate(-45deg);
+        }
+
+        &.disabled::before {
+          opacity: .2;
+        }
+      }
+    }
   }
 
   dl {

--- a/assets/components/base/_typography.css
+++ b/assets/components/base/_typography.css
@@ -203,7 +203,6 @@
     }
 
     &.steps {
-      @mixin inner-list-reset;
       max-width: var(--w-mid);
       counter-reset: steps;
       padding-left: 0;
@@ -216,6 +215,9 @@
         counter-increment: steps;
         list-style-type: none;
         position: relative;
+
+        /* reset inner lists */
+        @mixin inner-list-reset;
 
         &:first-child {
           border-top: none;

--- a/assets/components/base/_typography.css
+++ b/assets/components/base/_typography.css
@@ -265,7 +265,7 @@
         & > ol,
         & > ul {
           padding-top: 0;
-          padding-bottom: 1rem;
+          padding-bottom: 1.5rem;
         }
       }
 

--- a/assets/components/base/_typography.css
+++ b/assets/components/base/_typography.css
@@ -203,6 +203,7 @@
     }
 
     &.steps {
+      @mixin inner-list-reset;
       max-width: var(--w-mid);
       counter-reset: steps;
       padding-left: 0;
@@ -259,14 +260,6 @@
       ul {
         padding-left: 1.25rem;
         padding-right: 1.25rem;
-      }
-
-      & > li {
-        & > ol,
-        & > ul {
-          padding-top: 0;
-          padding-bottom: 1.5rem;
-        }
       }
 
       @media screen and (--bp-desktop) {

--- a/assets/shared/_globals.css
+++ b/assets/shared/_globals.css
@@ -204,11 +204,9 @@
  * For list components that may contain base lists - e.g. `ol.steps`, `ul.accordion`
  */
 @define-mixin inner-list-reset {
-  & > li {
-    & > ol,
-    & > ul {
-      padding-top: 0;
-      padding-bottom: 1.5rem;
-    }
+  & > ol,
+  & > ul {
+    padding-top: 0;
+    padding-bottom: 1.5rem;
   }
 }

--- a/assets/shared/_globals.css
+++ b/assets/shared/_globals.css
@@ -199,3 +199,16 @@
   border: 0;
 }
 
+/*
+ * Reset inner lists.
+ * For list components that may contain base lists - e.g. `ol.steps`, `ul.accordion`
+ */
+@define-mixin inner-list-reset {
+  & > li {
+    & > ol,
+    & > ul {
+      padding-top: 0;
+      padding-bottom: 1.5rem;
+    }
+  }
+}


### PR DESCRIPTION
Hopefully for the best...

- **Breaking change!** Deprecate using class `ticked-list` on a wrapper of the actual `ul` element.
- Fix and simplify spacing styles, especially with nested lists
- Fix #810 - all first-level lists now have 1.5rem bottom spacing; list items (last child excepted) have .5rem bottom spacing; and nested lists have .5rem top spacing and no bottom spacing.
- Keep only one list mixin, `inner-list-rest`, with much simpler styles, to specifically restore root list spacing to lists that are used inside list-based components (e.g. accordion, steps list).

Before | After
--- | ---
<img width="326" alt="screen shot 2017-05-16 at 2 28 59 pm" src="https://cloud.githubusercontent.com/assets/2936402/26089851/1b2ef1ee-3a44-11e7-8845-4a055dbd57ef.png"> | <img width="333" alt="screen shot 2017-05-16 at 2 29 15 pm" src="https://cloud.githubusercontent.com/assets/2936402/26089850/1b1dcdba-3a44-11e7-9d1f-6015cad2c248.png">
<img width="344" alt="screen shot 2017-05-16 at 2 31 32 pm" src="https://cloud.githubusercontent.com/assets/2936402/26089903/6c39ce56-3a44-11e7-9a81-2c6d8f538e1e.png"> | <img width="379" alt="screen shot 2017-05-17 at 12 25 36 pm" src="https://cloud.githubusercontent.com/assets/2936402/26135902/f72a317e-3afb-11e7-9b9a-b5d30a1e8399.png">


