### PR TITLE
Register and expose injection components

### DIFF
--- a/assets/components/footer/index.es6
+++ b/assets/components/footer/index.es6
@@ -14,6 +14,8 @@ function InjectFooter(props) {
   }
 }
 
+InjectFooter.label = 'InjectFooter';
+
 InjectFooter.prototype.renderFooter = function() {
   this.el = document.createElement('div');
   this.el.className = 'page-footer';

--- a/assets/components/header/index.es6
+++ b/assets/components/header/index.es6
@@ -9,7 +9,7 @@ var FIXED_THRESHOLD = 90 - 40; // height of static header minus height of fixed 
  * @param  {Object} props
  */
 function InjectHeader(props) {
-  this.props = props || {};
+  this.props = props || { defaultLink: 'https://www.unimelb.edu.au' };
 
   this.props.parent = document.querySelector('.uomcontent');
   this.props.page = document.querySelector('.page-inner');
@@ -27,6 +27,8 @@ function InjectHeader(props) {
   window.addEventListener('scroll', utils.throttle(this.handleScroll.bind(this), 100));
   this.handleScroll(); // Check once on page load
 }
+
+InjectHeader.label = 'InjectHeader';
 
 InjectHeader.prototype.renderPageHeader = function() {
   // Create header if it doesn't already exist

--- a/assets/components/icon-set/index.js
+++ b/assets/components/icon-set/index.js
@@ -14,4 +14,6 @@ function InjectIconSet() {
   document.querySelector('.uomcontent').appendChild(el);
 }
 
+InjectIconSet.label = 'InjectIconSet';
+
 module.exports = InjectIconSet;

--- a/assets/components/nav/index.es6
+++ b/assets/components/nav/index.es6
@@ -46,6 +46,8 @@ function InjectNav(props) {
   this.update();
 }
 
+InjectNav.label = 'InjectNav';
+
 InjectNav.prototype.setActiveNav = function(state) {
   this.props.activeNav = (state && state[HISTORY_KEY] ? state[HISTORY_KEY] : {
     local: false,

--- a/assets/shared/component-manager.es6
+++ b/assets/shared/component-manager.es6
@@ -7,6 +7,12 @@ import { cuid, loadStylesheet, loadScript } from 'utils';
 export const components = {};
 
 /**
+ * Registered injection components by label.
+ * @type {Object}
+ */
+export const injectionComponents = {};
+
+/**
  * Component instances by ID.
  * When a component is instantiated, a random ID is generated and set as the value of the `data-bound`
  * attribute on the component's root DOM element.
@@ -14,8 +20,14 @@ export const components = {};
 export const instances = {};
 
 /**
+ * Injection component instances by label.
+ * There's only one instance per component, so no need for random IDs.
+ */
+export const injectionInstances = {};
+
+/**
  * Register one or more components.
- * @param {array|constructor} components - an array of components, or a single component's constructor
+ * @param {array|constructor} comps - an array of components, or a single component's constructor
  */
 export function registerComponents(comps) {
   // Allow passing a single component
@@ -31,6 +43,27 @@ export function registerComponents(comps) {
 
     // Register component by label
     components[Component.label] = Component;
+  });
+}
+
+/**
+ * Register one or more injection components.
+ * @param {array|constructor} comps - an array of components, or a single component's constructor
+ */
+export function registerInjectionComponents(comps) {
+  // Allow passing a single injection component
+  comps = Array.isArray(comps) ? comps : [comps];
+
+  // Register every injection component
+  comps.forEach(Component => {
+    // Log error if component doesn't have a label
+    if (!Component.label) {
+      console.error('Injection component must have a label', Component);
+      return;
+    }
+
+    // Register injection component by label
+    injectionComponents[Component.label] = Component;
   });
 }
 
@@ -80,6 +113,16 @@ export function initComponent(label, context = document) {
 
   // No script dependencies or global ; initialise matches right away
   initMatches(Component, matches);
+}
+
+/**
+ * Initialise all registered injection components.
+ */
+export function applyInjection() {
+  Object.keys(injectionComponents).forEach((label) => {
+    const Component = injectionComponents[label];
+    injectionInstances[label] = new Component();
+  });
 }
 
 /**

--- a/assets/shared/create-namespace.js
+++ b/assets/shared/create-namespace.js
@@ -42,4 +42,6 @@ function CreateNameSpace() {
   }
 }
 
+CreateNameSpace.label = 'CreateNameSpace';
+
 module.exports = CreateNameSpace;

--- a/assets/targets/forms/index.es6
+++ b/assets/targets/forms/index.es6
@@ -24,6 +24,11 @@ window.uom = {
   vendor: { cssesc }
 };
 
+// Register the design system's injection components
+window.uom.registerInjectionComponents([
+  InjectIconSet
+]);
+
 // Register the design system's components
 window.uom.registerComponents([
   Accordion,
@@ -38,5 +43,5 @@ window.uom.registerComponents([
 document.documentElement.classList.remove('no-js');
 document.documentElement.classList.add('js');
 
-document.addEventListener('DOMContentLoaded', function inject() { new InjectIconSet(); });
+document.addEventListener('DOMContentLoaded', window.uom.applyInjection);
 document.addEventListener('DOMContentLoaded', window.uom.initAllComponents);

--- a/assets/targets/uom/index.es6
+++ b/assets/targets/uom/index.es6
@@ -40,7 +40,6 @@ require('shared/tracking');
 
 // Build API object
 window.uom = {
-  applyInjection,
   ...componentManager,
   utils,
   bus,
@@ -49,6 +48,15 @@ window.uom = {
     WebFont
   }
 };
+
+// Register the design system's injection components
+window.uom.registerInjectionComponents([
+  CreateNameSpace,
+  InjectHeader,
+  InjectNav,
+  InjectFooter,
+  InjectIconSet
+]);
 
 // Register the design system's components
 window.uom.registerComponents([
@@ -83,14 +91,3 @@ WebFont.load({ google: { families: [fonts] } });
 
 document.addEventListener('DOMContentLoaded', window.uom.applyInjection);
 document.addEventListener('DOMContentLoaded', window.uom.initAllComponents);
-
-/**
- * Initialise injection components.
- */
-function applyInjection() {
-  new CreateNameSpace();
-  new InjectHeader({ defaultLink: 'https://www.unimelb.edu.au' });
-  new InjectNav();
-  new InjectFooter();
-  new InjectIconSet();
-}


### PR DESCRIPTION
Add the following properties and methods to the component manager module, and expose them on the global `window.uom` object:

- `injectionComponents`: the registered injection components by label
- `injectionInstances`: the instances by label (an injection can only ever have one instance) 
- `registerInjectionComponents`: a method to register one or more injection component
- `applyInjection`: a method to initialise all registered injection components