### PR TITLE
Fix `div.figure` inside  sections

### DIFF
--- a/assets/components/figure/index.css
+++ b/assets/components/figure/index.css
@@ -1,4 +1,4 @@
-.uomcontent .figure {
+.uomcontent [role="main"] .figure {
   max-width: var(--w-sml);
   margin: 0 auto 1.5rem;
   text-align: center;


### PR DESCRIPTION
Increase specificity of `.figure` selectors to beat `.uomcontent [role="main"] section div`.