### PR TITLE
Search sortable tables

### DIFF
--- a/assets/components/tables/02-sortable-table.slim
+++ b/assets/components/tables/02-sortable-table.slim
@@ -3,31 +3,38 @@ table.zebra(data-sortable)
     tr
       th scope="col" Preference
       th scope="col" data-sort-as="text" Text
-      th(data-sort-skip scope="col") Offer made
-      th(data-sort-initial scope="col") Unit Code
-      th.right scope="col" Retail Price
+      th(data-sort-skip scope="col" data-sortable-search-type="select") Offer made
+      th(data-sort-initial scope="col" data-sortable-search-type="text") Unit Code
+      th(data-sort-initial scope="col" data-sortable-search-type="multi-select") Available
+      th.right scope="col" data-sortable-search-type="text" Retail Price
   tbody
     tr
       td 1
       td 50
       td Yes
       td ARTS_11
+      td
+        ' Semester 1
+        ' Semester 2
       td.right $29.99
     tr
       td 2
       td 300
       td No
       td ARTS_3
+      td Semester 1
       td.right $9.99
     tr
       td 4
       td 7
       td Yes
       td ARTS_100
+      td Semester 2
       td.right $39.99
     tr
       td 3
       td 6
       td Yes
       td ARTS_2
+      td Summer only
       td.right $109.99

--- a/assets/components/tables/_tables.css
+++ b/assets/components/tables/_tables.css
@@ -95,6 +95,21 @@
       padding-left: .625rem;
       padding-right: 1.25rem;
     }
+    td{
+      min-width: 9rem;
+    }
+  }
+
+  [data-sortable-multiselect] {
+    display: none;
+    position: absolute;
+    background: #fff;
+    padding: 1rem;
+    border: 1px solid #0076de;
+  }
+
+  [data-sortable-multiselect].visible {
+    display: block;
   }
 
   .right {
@@ -173,6 +188,38 @@
     tr:nth-child(odd) td {
       background-color: var(--col-paleblue);
     }
+  }
+
+  input[type="search"],
+  button{
+    border-radius: .2rem;
+    border: 1px solid #0076de;
+    padding: 0.1rem 0.3rem;
+    width: 100%;
+    text-align: left;
+    color: #0076de;
+    background: #fff;
+    line-height: 1.3rem;
+  }
+
+  button{
+    padding: 0rem 0.3rem;
+    font-family: Roboto,Helvetica,Arial,sans-serif;
+    font-weight: 300;
+    font-size: 1.125rem;
+    line-height: 1.525rem;
+  }
+
+  button:hover{
+    background-color: #e1eaf5;
+  }
+
+  .styled-select{
+    background-size: 24px;
+  }
+
+  .styled-select::-ms-expand {
+    display: none;
   }
 
   @media screen and (--bp-desktop) {

--- a/assets/components/tables/_tables.css
+++ b/assets/components/tables/_tables.css
@@ -261,6 +261,10 @@
           padding-bottom: .625rem;
         }
 
+        &.no-content {
+          padding: 0;
+        }
+
         &:empty {
           display: table-cell;
         }

--- a/assets/components/tables/sortable.js
+++ b/assets/components/tables/sortable.js
@@ -122,7 +122,11 @@ SortableTable.prototype.initSearchFields = function(el) {
   var row = document.createElement('tr');
   searchableCols.forEach(function(th) {
     var cellRef = row.insertCell(-1);
-    cellRef.insertAdjacentElement('beforeend', this.initSearchField(th));
+    var searchNode = this.initSearchField(th);
+    cellRef.insertAdjacentElement('beforeend', searchNode);
+    if (searchNode.firstChild.type === "hidden") {
+      cellRef.className = 'no-content';
+    }
   }, this);
   this.insertAfter(el.querySelectorAll('tr')[0], row);
 }

--- a/assets/utils/array-every-polyfill.js
+++ b/assets/utils/array-every-polyfill.js
@@ -1,0 +1,63 @@
+if (!Array.prototype.every) {
+  Array.prototype.every = function(callbackfn, thisArg) {
+    'use strict';
+    var T, k;
+
+    if (this == null) {
+      throw new TypeError('this is null or not defined');
+    }
+
+    // 1. Let O be the result of calling ToObject passing the this
+    //    value as the argument.
+    var O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get internal method
+    //    of O with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    var len = O.length >>> 0;
+
+    // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    if (typeof callbackfn !== 'function') {
+      throw new TypeError();
+    }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    if (arguments.length > 1) {
+      T = thisArg;
+    }
+
+    // 6. Let k be 0.
+    k = 0;
+
+    // 7. Repeat, while k < len
+    while (k < len) {
+
+      var kValue;
+
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty internal
+      //    method of O with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      if (k in O) {
+
+        // i. Let kValue be the result of calling the Get internal method
+        //    of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Let testResult be the result of calling the Call internal method
+        //     of callbackfn with T as the this value and argument list
+        //     containing kValue, k, and O.
+        var testResult = callbackfn.call(T, kValue, k, O);
+
+        // iii. If ToBoolean(testResult) is false, return false.
+        if (!testResult) {
+          return false;
+        }
+      }
+      k++;
+    }
+    return true;
+  };
+}

--- a/assets/utils/array-foreach-polyfill.js
+++ b/assets/utils/array-foreach-polyfill.js
@@ -1,0 +1,63 @@
+// Production steps of ECMA-262, Edition 5, 15.4.4.18
+// Reference: http://es5.github.io/#x15.4.4.18
+
+if (!Array.prototype.forEach) {
+    Array.prototype.forEach = function(callback/*, thisArg*/) {
+
+      var T, k;
+
+      if (this == null) {
+        throw new TypeError('this is null or not defined');
+      }
+
+      // 1. Let O be the result of calling toObject() passing the
+      // |this| value as the argument.
+      var O = Object(this);
+
+      // 2. Let lenValue be the result of calling the Get() internal
+      // method of O with the argument "length".
+      // 3. Let len be toUint32(lenValue).
+      var len = O.length >>> 0;
+
+      // 4. If isCallable(callback) is false, throw a TypeError exception.
+      // See: http://es5.github.com/#x9.11
+      if (typeof callback !== 'function') {
+        throw new TypeError(callback + ' is not a function');
+      }
+
+      // 5. If thisArg was supplied, let T be thisArg; else let
+      // T be undefined.
+      if (arguments.length > 1) {
+        T = arguments[1];
+      }
+
+      // 6. Let k be 0.
+      k = 0;
+
+      // 7. Repeat while k < len.
+      while (k < len) {
+
+        var kValue;
+
+        // a. Let Pk be ToString(k).
+        //    This is implicit for LHS operands of the in operator.
+        // b. Let kPresent be the result of calling the HasProperty
+        //    internal method of O with argument Pk.
+        //    This step can be combined with c.
+        // c. If kPresent is true, then
+        if (k in O) {
+
+          // i. Let kValue be the result of calling the Get internal
+          // method of O with argument Pk.
+          kValue = O[k];
+
+          // ii. Call the Call internal method of callback with T as
+          // the this value and argument list containing kValue, k, and O.
+          callback.call(T, kValue, k, O);
+        }
+        // d. Increase k by 1.
+        k++;
+      }
+      // 8. return undefined.
+    };
+  }

--- a/assets/utils/array-includes-polyfill.js
+++ b/assets/utils/array-includes-polyfill.js
@@ -1,0 +1,51 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, 'includes', {
+    value: function(searchElement, fromIndex) {
+
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+      function sameValueZero(x, y) {
+        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+      }
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        // c. Increase k by 1.
+        if (sameValueZero(o[k], searchElement)) {
+          return true;
+        }
+        k++;
+      }
+
+      // 8. Return false
+      return false;
+    }
+  });
+}

--- a/assets/utils/array-some-polyfill.js
+++ b/assets/utils/array-some-polyfill.js
@@ -1,0 +1,27 @@
+// Production steps of ECMA-262, Edition 5, 15.4.4.17
+// Reference: http://es5.github.io/#x15.4.4.17
+if (!Array.prototype.some) {
+  Array.prototype.some = function(fun/*, thisArg*/) {
+    'use strict';
+
+    if (this == null) {
+      throw new TypeError('Array.prototype.some called on null or undefined');
+    }
+
+    if (typeof fun !== 'function') {
+      throw new TypeError();
+    }
+
+    var t = Object(this);
+    var len = t.length >>> 0;
+
+    var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+    for (var i = 0; i < len; i++) {
+      if (i in t && fun.call(thisArg, t[i], i, t)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "normalize.css": "^5.0.0",
+    "object.values": "^1.0.4",
     "perfect-scrollbar": "^0.7.0",
     "photoswipe": "^4.1.1",
     "string-hash": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,13 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
@@ -1414,6 +1421,24 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.6.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 es6-promise@^4.0.5:
   version "4.1.0"
@@ -1615,6 +1640,10 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -1663,7 +1692,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2:
+function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
@@ -1993,6 +2022,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
@@ -2061,11 +2098,21 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
   dependencies:
     html-comment-regex "^1.1.0"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2518,12 +2565,25 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 obuf@^1.0.0, obuf@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
This PR adds filtering and searching to the sortable-table view.

In order to search a column, a `data-sortable-search-type='some_type'` must be added to its `th`.

Right now there are a handful of search "types".
`text`: will display a search input
`select`: will show a select box with options aggregated from the given column
`multi-select`: will show a button top open a multi-select dialog with options aggregated from the given column

In the case that no search type is given, a `td` with an hidden field is inserted so that when we collect search criteria, the index of each bit of data is the same as the column number.

The filtering is preformed by: 
1. Create a copy of the table body as a `documentFragment`. 
2. Duplicate that fragment
3. Compare each of the rows with an array of input data
4. If the text from every field is present in every cell, we consider that row a match
5. If it is not, we remove it from the copied fragment
6. Once we have compared every row, we replace the table body with the copied fragment 
7. rebuild the store we use for sorting

![multi-select](https://user-images.githubusercontent.com/479627/29851856-e0b724ee-8d79-11e7-896a-e2797dfefae1.gif)
